### PR TITLE
[Database] feat: create initial database migrations (#10)

### DIFF
--- a/backend/src/main/resources/db/migration/V001__initial_setup.sql
+++ b/backend/src/main/resources/db/migration/V001__initial_setup.sql
@@ -1,0 +1,32 @@
+-- V001__initial_setup.sql
+-- Description: Initial database setup - extensions, functions, and common utilities
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+-- Enable required extensions
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+-- Create function for auto-updating updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create enum types for status fields
+CREATE TYPE requirement_status AS ENUM ('DRAFT', 'ACTIVE', 'ARCHIVED', 'DELETED');
+CREATE TYPE api_spec_status AS ENUM ('ACTIVE', 'DEPRECATED', 'ARCHIVED');
+CREATE TYPE test_suite_status AS ENUM ('ACTIVE', 'DISABLED', 'ARCHIVED');
+CREATE TYPE scenario_status AS ENUM ('ACTIVE', 'DISABLED', 'DELETED');
+CREATE TYPE scenario_source AS ENUM ('AI_GENERATED', 'MANUAL', 'IMPORTED');
+CREATE TYPE run_status AS ENUM ('PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED');
+CREATE TYPE step_result_status AS ENUM ('PENDING', 'RUNNING', 'PASSED', 'FAILED', 'SKIPPED', 'ERROR');
+CREATE TYPE qa_package_status AS ENUM ('REQUESTED', 'SPEC_FETCHED', 'GENERATING', 'EXECUTING', 'EVALUATING', 'COMPLETED', 'FAILED');
+CREATE TYPE ai_log_status AS ENUM ('SUCCESS', 'FAILED', 'TIMEOUT', 'RATE_LIMITED');
+CREATE TYPE test_mode AS ENUM ('STANDARD', 'SECURITY', 'PERFORMANCE');
+
+-- Add comments for documentation
+COMMENT ON FUNCTION update_updated_at_column() IS 'Trigger function to automatically update updated_at column on row modification';

--- a/backend/src/main/resources/db/migration/V002__create_requirements_table.sql
+++ b/backend/src/main/resources/db/migration/V002__create_requirements_table.sql
@@ -1,0 +1,38 @@
+-- V002__create_requirements_table.sql
+-- Description: Create requirements table for business requirements tracking
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE requirements (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    title VARCHAR(500) NOT NULL,
+    description TEXT,
+    external_reference VARCHAR(255),
+    external_url VARCHAR(2048),
+    status requirement_status NOT NULL DEFAULT 'DRAFT',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255),
+
+    CONSTRAINT chk_title_not_empty CHECK (LENGTH(TRIM(title)) > 0),
+    CONSTRAINT chk_external_url_format CHECK (external_url IS NULL OR external_url ~ '^https?://')
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_requirements_status ON requirements(status);
+CREATE INDEX idx_requirements_created_at ON requirements(created_at DESC);
+CREATE INDEX idx_requirements_external_ref ON requirements(external_reference) WHERE external_reference IS NOT NULL;
+CREATE INDEX idx_requirements_title_search ON requirements USING gin(title gin_trgm_ops);
+
+-- Trigger for updated_at
+CREATE TRIGGER tr_requirements_updated_at
+    BEFORE UPDATE ON requirements
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Table comments
+COMMENT ON TABLE requirements IS 'Business requirements that drive test scenario generation';
+COMMENT ON COLUMN requirements.external_reference IS 'Reference to external system (e.g., Jira ticket ID)';
+COMMENT ON COLUMN requirements.external_url IS 'URL to external requirement document';
+COMMENT ON COLUMN requirements.metadata IS 'Additional structured data (tags, priority, etc.)';

--- a/backend/src/main/resources/db/migration/V003__create_api_specs_table.sql
+++ b/backend/src/main/resources/db/migration/V003__create_api_specs_table.sql
@@ -1,0 +1,48 @@
+-- V003__create_api_specs_table.sql
+-- Description: Create api_specs table for OpenAPI specification storage
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE api_specs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    spec_url VARCHAR(2048),
+    raw_content TEXT,
+    content_hash VARCHAR(64),
+    version VARCHAR(50),
+    format VARCHAR(20) DEFAULT 'OPENAPI_3',
+    status api_spec_status NOT NULL DEFAULT 'ACTIVE',
+    operations_count INTEGER DEFAULT 0,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255),
+
+    CONSTRAINT chk_name_not_empty CHECK (LENGTH(TRIM(name)) > 0),
+    CONSTRAINT chk_spec_url_format CHECK (spec_url IS NULL OR spec_url ~ '^https?://'),
+    CONSTRAINT chk_has_spec CHECK (spec_url IS NOT NULL OR raw_content IS NOT NULL),
+    CONSTRAINT chk_format CHECK (format IN ('OPENAPI_3', 'OPENAPI_2', 'SWAGGER', 'RAML', 'GRAPHQL'))
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_api_specs_status ON api_specs(status);
+CREATE INDEX idx_api_specs_created_at ON api_specs(created_at DESC);
+CREATE INDEX idx_api_specs_content_hash ON api_specs(content_hash) WHERE content_hash IS NOT NULL;
+CREATE INDEX idx_api_specs_name_search ON api_specs USING gin(name gin_trgm_ops);
+
+-- Partial index for active specs
+CREATE INDEX idx_api_specs_active ON api_specs(created_at DESC) WHERE status = 'ACTIVE';
+
+-- Trigger for updated_at
+CREATE TRIGGER tr_api_specs_updated_at
+    BEFORE UPDATE ON api_specs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Table comments
+COMMENT ON TABLE api_specs IS 'OpenAPI specifications for systems under test';
+COMMENT ON COLUMN api_specs.spec_url IS 'URL to fetch the OpenAPI specification';
+COMMENT ON COLUMN api_specs.raw_content IS 'Cached raw content of the specification (YAML/JSON)';
+COMMENT ON COLUMN api_specs.content_hash IS 'SHA-256 hash of raw_content for change detection';
+COMMENT ON COLUMN api_specs.operations_count IS 'Number of operations in the spec';

--- a/backend/src/main/resources/db/migration/V004__create_test_suites_table.sql
+++ b/backend/src/main/resources/db/migration/V004__create_test_suites_table.sql
@@ -1,0 +1,46 @@
+-- V004__create_test_suites_table.sql
+-- Description: Create test_suites table for grouping test scenarios
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE test_suites (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    requirement_id UUID REFERENCES requirements(id) ON DELETE SET NULL,
+    api_spec_id UUID REFERENCES api_specs(id) ON DELETE SET NULL,
+    default_base_url VARCHAR(2048),
+    status test_suite_status NOT NULL DEFAULT 'ACTIVE',
+    tags VARCHAR(100)[] DEFAULT '{}',
+    config JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255),
+
+    CONSTRAINT chk_name_not_empty CHECK (LENGTH(TRIM(name)) > 0),
+    CONSTRAINT chk_base_url_format CHECK (default_base_url IS NULL OR default_base_url ~ '^https?://')
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_test_suites_status ON test_suites(status);
+CREATE INDEX idx_test_suites_requirement_id ON test_suites(requirement_id);
+CREATE INDEX idx_test_suites_api_spec_id ON test_suites(api_spec_id);
+CREATE INDEX idx_test_suites_created_at ON test_suites(created_at DESC);
+CREATE INDEX idx_test_suites_tags ON test_suites USING gin(tags);
+CREATE INDEX idx_test_suites_name_search ON test_suites USING gin(name gin_trgm_ops);
+
+-- Partial index for active suites
+CREATE INDEX idx_test_suites_active ON test_suites(created_at DESC) WHERE status = 'ACTIVE';
+
+-- Trigger for updated_at
+CREATE TRIGGER tr_test_suites_updated_at
+    BEFORE UPDATE ON test_suites
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Table comments
+COMMENT ON TABLE test_suites IS 'Logical grouping of test scenarios';
+COMMENT ON COLUMN test_suites.requirement_id IS 'Optional link to source requirement';
+COMMENT ON COLUMN test_suites.api_spec_id IS 'Optional link to API specification';
+COMMENT ON COLUMN test_suites.default_base_url IS 'Default base URL for test execution';
+COMMENT ON COLUMN test_suites.config IS 'Suite-level configuration (timeouts, retries, etc.)';

--- a/backend/src/main/resources/db/migration/V005__create_test_scenarios_table.sql
+++ b/backend/src/main/resources/db/migration/V005__create_test_scenarios_table.sql
@@ -1,0 +1,86 @@
+-- V005__create_test_scenarios_table.sql
+-- Description: Create test_scenarios table with embedded test steps
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE test_scenarios (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    suite_id UUID REFERENCES test_suites(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    source scenario_source NOT NULL DEFAULT 'AI_GENERATED',
+    operation_id VARCHAR(255),
+    steps_json JSONB NOT NULL,
+    status scenario_status NOT NULL DEFAULT 'ACTIVE',
+    tags VARCHAR(100)[] DEFAULT '{}',
+    priority INTEGER DEFAULT 0,
+    version INTEGER DEFAULT 1,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255),
+
+    CONSTRAINT chk_name_not_empty CHECK (LENGTH(TRIM(name)) > 0),
+    CONSTRAINT chk_steps_json_is_array CHECK (jsonb_typeof(steps_json) = 'array'),
+    CONSTRAINT chk_steps_not_empty CHECK (jsonb_array_length(steps_json) > 0),
+    CONSTRAINT chk_priority_range CHECK (priority >= 0 AND priority <= 10)
+);
+
+-- Create function to validate steps_json structure
+CREATE OR REPLACE FUNCTION validate_test_steps(steps JSONB)
+RETURNS BOOLEAN AS $$
+DECLARE
+    step JSONB;
+BEGIN
+    -- Check it's an array
+    IF jsonb_typeof(steps) != 'array' THEN
+        RETURN FALSE;
+    END IF;
+
+    -- Check each step has required fields
+    FOR step IN SELECT * FROM jsonb_array_elements(steps)
+    LOOP
+        IF NOT (
+            step ? 'name' AND
+            step ? 'method' AND
+            step ? 'endpoint'
+        ) THEN
+            RETURN FALSE;
+        END IF;
+    END LOOP;
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Add constraint using the validation function
+ALTER TABLE test_scenarios
+ADD CONSTRAINT chk_steps_json_structure CHECK (validate_test_steps(steps_json));
+
+-- Indexes for common queries
+CREATE INDEX idx_test_scenarios_suite_id ON test_scenarios(suite_id);
+CREATE INDEX idx_test_scenarios_status ON test_scenarios(status);
+CREATE INDEX idx_test_scenarios_source ON test_scenarios(source);
+CREATE INDEX idx_test_scenarios_operation_id ON test_scenarios(operation_id) WHERE operation_id IS NOT NULL;
+CREATE INDEX idx_test_scenarios_created_at ON test_scenarios(created_at DESC);
+CREATE INDEX idx_test_scenarios_tags ON test_scenarios USING gin(tags);
+CREATE INDEX idx_test_scenarios_steps_json ON test_scenarios USING gin(steps_json jsonb_path_ops);
+CREATE INDEX idx_test_scenarios_name_search ON test_scenarios USING gin(name gin_trgm_ops);
+
+-- Partial index for active scenarios
+CREATE INDEX idx_test_scenarios_active ON test_scenarios(suite_id, created_at DESC) WHERE status = 'ACTIVE';
+
+-- Trigger for updated_at
+CREATE TRIGGER tr_test_scenarios_updated_at
+    BEFORE UPDATE ON test_scenarios
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Table comments
+COMMENT ON TABLE test_scenarios IS 'Test scenarios containing ordered test steps as JSON';
+COMMENT ON COLUMN test_scenarios.source IS 'How the scenario was created (AI, manual, imported)';
+COMMENT ON COLUMN test_scenarios.operation_id IS 'OpenAPI operation ID this scenario tests';
+COMMENT ON COLUMN test_scenarios.steps_json IS 'Array of test steps with method, endpoint, headers, body, expected, extractions';
+COMMENT ON COLUMN test_scenarios.version IS 'Scenario version for tracking changes';
+COMMENT ON COLUMN test_scenarios.priority IS 'Execution priority (0-10, higher = more important)';
+COMMENT ON FUNCTION validate_test_steps(JSONB) IS 'Validates test steps JSON structure';

--- a/backend/src/main/resources/db/migration/V006__create_test_runs_table.sql
+++ b/backend/src/main/resources/db/migration/V006__create_test_runs_table.sql
@@ -1,0 +1,60 @@
+-- V006__create_test_runs_table.sql
+-- Description: Create test_runs table for tracking test executions
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE test_runs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    scenario_id UUID NOT NULL REFERENCES test_scenarios(id) ON DELETE CASCADE,
+    qa_package_id UUID,
+    base_url VARCHAR(2048) NOT NULL,
+    status run_status NOT NULL DEFAULT 'PENDING',
+    triggered_by VARCHAR(255),
+    trigger_source VARCHAR(50) DEFAULT 'MANUAL',
+    config_json JSONB DEFAULT '{}',
+    summary_json JSONB,
+    steps_total INTEGER DEFAULT 0,
+    steps_passed INTEGER DEFAULT 0,
+    steps_failed INTEGER DEFAULT 0,
+    steps_skipped INTEGER DEFAULT 0,
+    duration_ms BIGINT,
+    error_message TEXT,
+    started_at TIMESTAMP WITH TIME ZONE,
+    finished_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_base_url_format CHECK (base_url ~ '^https?://'),
+    CONSTRAINT chk_trigger_source CHECK (trigger_source IN ('MANUAL', 'SCHEDULED', 'CI_CD', 'API', 'REPLAY')),
+    CONSTRAINT chk_steps_counts CHECK (
+        steps_total >= 0 AND
+        steps_passed >= 0 AND
+        steps_failed >= 0 AND
+        steps_skipped >= 0 AND
+        steps_passed + steps_failed + steps_skipped <= steps_total
+    ),
+    CONSTRAINT chk_duration_positive CHECK (duration_ms IS NULL OR duration_ms >= 0)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_test_runs_scenario_id ON test_runs(scenario_id);
+CREATE INDEX idx_test_runs_qa_package_id ON test_runs(qa_package_id) WHERE qa_package_id IS NOT NULL;
+CREATE INDEX idx_test_runs_status ON test_runs(status);
+CREATE INDEX idx_test_runs_created_at ON test_runs(created_at DESC);
+CREATE INDEX idx_test_runs_started_at ON test_runs(started_at DESC) WHERE started_at IS NOT NULL;
+
+-- Composite indexes for common query patterns
+CREATE INDEX idx_test_runs_scenario_status ON test_runs(scenario_id, status);
+CREATE INDEX idx_test_runs_scenario_latest ON test_runs(scenario_id, created_at DESC);
+
+-- Partial indexes for active/recent runs
+CREATE INDEX idx_test_runs_pending ON test_runs(created_at) WHERE status = 'PENDING';
+CREATE INDEX idx_test_runs_running ON test_runs(started_at) WHERE status = 'RUNNING';
+CREATE INDEX idx_test_runs_failed ON test_runs(created_at DESC) WHERE status = 'FAILED';
+
+-- Table comments
+COMMENT ON TABLE test_runs IS 'Execution instances of test scenarios';
+COMMENT ON COLUMN test_runs.qa_package_id IS 'Reference to parent QA package if part of a batch run';
+COMMENT ON COLUMN test_runs.trigger_source IS 'How the run was triggered (manual, scheduled, CI/CD, API)';
+COMMENT ON COLUMN test_runs.config_json IS 'Run-specific configuration overrides';
+COMMENT ON COLUMN test_runs.summary_json IS 'Execution summary and statistics';
+COMMENT ON COLUMN test_runs.duration_ms IS 'Total execution duration in milliseconds';

--- a/backend/src/main/resources/db/migration/V007__create_test_step_results_table.sql
+++ b/backend/src/main/resources/db/migration/V007__create_test_step_results_table.sql
@@ -1,0 +1,66 @@
+-- V007__create_test_step_results_table.sql
+-- Description: Create test_step_results table for per-step execution results
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE test_step_results (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    run_id UUID NOT NULL REFERENCES test_runs(id) ON DELETE CASCADE,
+    step_index INTEGER NOT NULL,
+    step_name VARCHAR(255) NOT NULL,
+    status step_result_status NOT NULL DEFAULT 'PENDING',
+
+    -- Request details
+    request_method VARCHAR(10) NOT NULL,
+    request_url VARCHAR(4096) NOT NULL,
+    request_headers JSONB DEFAULT '{}',
+    request_body TEXT,
+
+    -- Response details
+    actual_status INTEGER,
+    actual_headers JSONB,
+    actual_body TEXT,
+    response_size_bytes INTEGER,
+
+    -- Evaluation details
+    expected_status INTEGER,
+    expected_body_fields JSONB,
+    assertions_json JSONB,
+    passed BOOLEAN,
+    failure_reason TEXT,
+
+    -- Extracted values for chaining
+    extractions_json JSONB DEFAULT '{}',
+
+    -- Timing
+    duration_ms INTEGER,
+    started_at TIMESTAMP WITH TIME ZONE,
+    finished_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_step_index_positive CHECK (step_index >= 0),
+    CONSTRAINT chk_request_method CHECK (request_method IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')),
+    CONSTRAINT chk_duration_positive CHECK (duration_ms IS NULL OR duration_ms >= 0),
+    CONSTRAINT chk_response_size_positive CHECK (response_size_bytes IS NULL OR response_size_bytes >= 0),
+    CONSTRAINT uq_run_step UNIQUE (run_id, step_index)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_test_step_results_run_id ON test_step_results(run_id);
+CREATE INDEX idx_test_step_results_status ON test_step_results(status);
+CREATE INDEX idx_test_step_results_passed ON test_step_results(passed) WHERE passed IS NOT NULL;
+CREATE INDEX idx_test_step_results_created_at ON test_step_results(created_at DESC);
+
+-- Composite index for ordering steps within a run
+CREATE INDEX idx_test_step_results_run_order ON test_step_results(run_id, step_index);
+
+-- Partial indexes for failed/slow steps
+CREATE INDEX idx_test_step_results_failed ON test_step_results(run_id) WHERE status = 'FAILED';
+CREATE INDEX idx_test_step_results_slow ON test_step_results(duration_ms DESC) WHERE duration_ms > 1000;
+
+-- Table comments
+COMMENT ON TABLE test_step_results IS 'Per-step execution results for test runs';
+COMMENT ON COLUMN test_step_results.step_index IS 'Zero-based index of the step within the scenario';
+COMMENT ON COLUMN test_step_results.assertions_json IS 'Detailed assertion results (expected vs actual)';
+COMMENT ON COLUMN test_step_results.extractions_json IS 'Values extracted from response for use in subsequent steps';
+COMMENT ON COLUMN test_step_results.failure_reason IS 'Human-readable explanation of why the step failed';

--- a/backend/src/main/resources/db/migration/V008__create_qa_packages_table.sql
+++ b/backend/src/main/resources/db/migration/V008__create_qa_packages_table.sql
@@ -1,0 +1,104 @@
+-- V008__create_qa_packages_table.sql
+-- Description: Create qa_packages table for full test runs with AI evaluation
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE qa_packages (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    requirement_id UUID REFERENCES requirements(id) ON DELETE SET NULL,
+    api_spec_id UUID REFERENCES api_specs(id) ON DELETE SET NULL,
+    spec_url VARCHAR(2048),
+    base_url VARCHAR(2048) NOT NULL,
+    mode test_mode NOT NULL DEFAULT 'STANDARD',
+    status qa_package_status NOT NULL DEFAULT 'REQUESTED',
+
+    -- Cached spec info
+    spec_hash VARCHAR(64),
+    spec_content TEXT,
+
+    -- Execution config
+    config_json JSONB DEFAULT '{}',
+    timeout_ms INTEGER DEFAULT 30000,
+    max_retries INTEGER DEFAULT 3,
+
+    -- Results summary
+    scenarios_total INTEGER DEFAULT 0,
+    scenarios_passed INTEGER DEFAULT 0,
+    scenarios_failed INTEGER DEFAULT 0,
+    scenarios_skipped INTEGER DEFAULT 0,
+    operations_total INTEGER DEFAULT 0,
+    operations_covered INTEGER DEFAULT 0,
+
+    -- AI evaluation
+    qa_summary TEXT,
+    qa_recommendations JSONB DEFAULT '[]',
+    coverage_json JSONB DEFAULT '{}',
+
+    -- Stored payload for replay
+    payload_json JSONB,
+    payload_compressed BYTEA,
+
+    -- Error handling
+    error_message TEXT,
+    error_details JSONB,
+
+    -- Timing
+    started_at TIMESTAMP WITH TIME ZONE,
+    finished_at TIMESTAMP WITH TIME ZONE,
+    duration_ms BIGINT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255),
+
+    CONSTRAINT chk_name_not_empty CHECK (LENGTH(TRIM(name)) > 0),
+    CONSTRAINT chk_base_url_format CHECK (base_url ~ '^https?://'),
+    CONSTRAINT chk_spec_url_format CHECK (spec_url IS NULL OR spec_url ~ '^https?://'),
+    CONSTRAINT chk_timeout_positive CHECK (timeout_ms > 0),
+    CONSTRAINT chk_retries_range CHECK (max_retries >= 0 AND max_retries <= 10),
+    CONSTRAINT chk_scenarios_counts CHECK (
+        scenarios_total >= 0 AND
+        scenarios_passed >= 0 AND
+        scenarios_failed >= 0 AND
+        scenarios_skipped >= 0
+    ),
+    CONSTRAINT chk_duration_positive CHECK (duration_ms IS NULL OR duration_ms >= 0)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_qa_packages_status ON qa_packages(status);
+CREATE INDEX idx_qa_packages_mode ON qa_packages(mode);
+CREATE INDEX idx_qa_packages_requirement_id ON qa_packages(requirement_id) WHERE requirement_id IS NOT NULL;
+CREATE INDEX idx_qa_packages_api_spec_id ON qa_packages(api_spec_id) WHERE api_spec_id IS NOT NULL;
+CREATE INDEX idx_qa_packages_spec_hash ON qa_packages(spec_hash) WHERE spec_hash IS NOT NULL;
+CREATE INDEX idx_qa_packages_created_at ON qa_packages(created_at DESC);
+CREATE INDEX idx_qa_packages_started_at ON qa_packages(started_at DESC) WHERE started_at IS NOT NULL;
+CREATE INDEX idx_qa_packages_name_search ON qa_packages USING gin(name gin_trgm_ops);
+
+-- Partial indexes for status filtering
+CREATE INDEX idx_qa_packages_pending ON qa_packages(created_at) WHERE status IN ('REQUESTED', 'SPEC_FETCHED', 'GENERATING');
+CREATE INDEX idx_qa_packages_running ON qa_packages(started_at) WHERE status IN ('EXECUTING', 'EVALUATING');
+CREATE INDEX idx_qa_packages_completed ON qa_packages(finished_at DESC) WHERE status = 'COMPLETED';
+CREATE INDEX idx_qa_packages_failed ON qa_packages(created_at DESC) WHERE status = 'FAILED';
+
+-- Trigger for updated_at
+CREATE TRIGGER tr_qa_packages_updated_at
+    BEFORE UPDATE ON qa_packages
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- Add foreign key from test_runs to qa_packages (deferred because qa_packages created after test_runs)
+ALTER TABLE test_runs
+ADD CONSTRAINT fk_test_runs_qa_package
+FOREIGN KEY (qa_package_id) REFERENCES qa_packages(id) ON DELETE CASCADE;
+
+-- Table comments
+COMMENT ON TABLE qa_packages IS 'Container for full test runs with AI evaluation and coverage reporting';
+COMMENT ON COLUMN qa_packages.mode IS 'Test mode: STANDARD (functional), SECURITY (OWASP), PERFORMANCE (load)';
+COMMENT ON COLUMN qa_packages.spec_hash IS 'SHA-256 hash of the OpenAPI spec for version tracking';
+COMMENT ON COLUMN qa_packages.qa_summary IS 'AI-generated summary of test results';
+COMMENT ON COLUMN qa_packages.qa_recommendations IS 'AI-generated recommendations for improvement';
+COMMENT ON COLUMN qa_packages.coverage_json IS 'Per-operation coverage details';
+COMMENT ON COLUMN qa_packages.payload_json IS 'Stored payload for deterministic replay';
+COMMENT ON COLUMN qa_packages.payload_compressed IS 'Gzip-compressed payload for large payloads';

--- a/backend/src/main/resources/db/migration/V009__create_ai_logs_table.sql
+++ b/backend/src/main/resources/db/migration/V009__create_ai_logs_table.sql
@@ -1,0 +1,75 @@
+-- V009__create_ai_logs_table.sql
+-- Description: Create ai_logs table for tracking AI interactions
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+CREATE TABLE ai_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    correlation_id UUID,
+    qa_package_id UUID REFERENCES qa_packages(id) ON DELETE SET NULL,
+
+    -- Provider info
+    provider VARCHAR(50) NOT NULL,
+    model VARCHAR(100) NOT NULL,
+    prompt_type VARCHAR(50) NOT NULL,
+
+    -- Token usage
+    prompt_tokens INTEGER,
+    completion_tokens INTEGER,
+    total_tokens INTEGER,
+
+    -- Request/Response
+    prompt_hash VARCHAR(64),
+    prompt_text TEXT NOT NULL,
+    response_text TEXT,
+    response_json JSONB,
+
+    -- Status and error handling
+    status ai_log_status NOT NULL,
+    error_message TEXT,
+    error_code VARCHAR(50),
+
+    -- Timing
+    duration_ms INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_provider_not_empty CHECK (LENGTH(TRIM(provider)) > 0),
+    CONSTRAINT chk_model_not_empty CHECK (LENGTH(TRIM(model)) > 0),
+    CONSTRAINT chk_prompt_type CHECK (prompt_type IN (
+        'SCENARIO_GENERATION',
+        'RESULT_EVALUATION',
+        'QA_SUMMARY',
+        'REQUIREMENTS_ANALYSIS',
+        'SECURITY_SCAN',
+        'PERFORMANCE_ANALYSIS',
+        'OTHER'
+    )),
+    CONSTRAINT chk_tokens_positive CHECK (
+        (prompt_tokens IS NULL OR prompt_tokens >= 0) AND
+        (completion_tokens IS NULL OR completion_tokens >= 0) AND
+        (total_tokens IS NULL OR total_tokens >= 0)
+    ),
+    CONSTRAINT chk_duration_positive CHECK (duration_ms IS NULL OR duration_ms >= 0)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_ai_logs_correlation_id ON ai_logs(correlation_id) WHERE correlation_id IS NOT NULL;
+CREATE INDEX idx_ai_logs_qa_package_id ON ai_logs(qa_package_id) WHERE qa_package_id IS NOT NULL;
+CREATE INDEX idx_ai_logs_provider ON ai_logs(provider);
+CREATE INDEX idx_ai_logs_model ON ai_logs(provider, model);
+CREATE INDEX idx_ai_logs_prompt_type ON ai_logs(prompt_type);
+CREATE INDEX idx_ai_logs_status ON ai_logs(status);
+CREATE INDEX idx_ai_logs_prompt_hash ON ai_logs(prompt_hash) WHERE prompt_hash IS NOT NULL;
+CREATE INDEX idx_ai_logs_created_at ON ai_logs(created_at DESC);
+
+-- Partial indexes for error analysis
+CREATE INDEX idx_ai_logs_errors ON ai_logs(created_at DESC) WHERE status != 'SUCCESS';
+CREATE INDEX idx_ai_logs_rate_limited ON ai_logs(created_at DESC) WHERE status = 'RATE_LIMITED';
+CREATE INDEX idx_ai_logs_slow ON ai_logs(duration_ms DESC) WHERE duration_ms > 5000;
+
+-- Table comments
+COMMENT ON TABLE ai_logs IS 'Audit log of all AI provider interactions';
+COMMENT ON COLUMN ai_logs.correlation_id IS 'Correlation ID for tracking related requests';
+COMMENT ON COLUMN ai_logs.prompt_type IS 'Type of AI operation performed';
+COMMENT ON COLUMN ai_logs.prompt_hash IS 'SHA-256 hash of prompt for deduplication/caching analysis';
+COMMENT ON COLUMN ai_logs.response_json IS 'Parsed JSON response if applicable';

--- a/backend/src/main/resources/db/migration/V010__create_events_table.sql
+++ b/backend/src/main/resources/db/migration/V010__create_events_table.sql
@@ -1,0 +1,50 @@
+-- V010__create_events_table.sql
+-- Description: Create events table for tracking QA package state transitions
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+-- Event types enum
+CREATE TYPE event_type AS ENUM (
+    'REQUESTED',
+    'SPEC_FETCHED',
+    'SPEC_FETCH_FAILED',
+    'SCENARIO_CREATED',
+    'SCENARIO_GENERATION_FAILED',
+    'EXECUTION_STARTED',
+    'EXECUTION_SUCCESS',
+    'EXECUTION_FAILED',
+    'AI_SUCCESS',
+    'AI_FAILED',
+    'QA_EVAL_STARTED',
+    'QA_EVAL_DONE',
+    'QA_EVAL_FAILED',
+    'COMPLETE',
+    'FAILED',
+    'CANCELLED'
+);
+
+CREATE TABLE qa_package_events (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    qa_package_id UUID NOT NULL REFERENCES qa_packages(id) ON DELETE CASCADE,
+    event_type event_type NOT NULL,
+    event_data JSONB DEFAULT '{}',
+    scenario_id UUID REFERENCES test_scenarios(id) ON DELETE SET NULL,
+    run_id UUID REFERENCES test_runs(id) ON DELETE SET NULL,
+    error_message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_qa_package_events_package_id ON qa_package_events(qa_package_id);
+CREATE INDEX idx_qa_package_events_type ON qa_package_events(event_type);
+CREATE INDEX idx_qa_package_events_created_at ON qa_package_events(created_at DESC);
+CREATE INDEX idx_qa_package_events_scenario_id ON qa_package_events(scenario_id) WHERE scenario_id IS NOT NULL;
+CREATE INDEX idx_qa_package_events_run_id ON qa_package_events(run_id) WHERE run_id IS NOT NULL;
+
+-- Composite index for event timeline
+CREATE INDEX idx_qa_package_events_timeline ON qa_package_events(qa_package_id, created_at);
+
+-- Table comments
+COMMENT ON TABLE qa_package_events IS 'Event log for QA package state transitions and progress tracking';
+COMMENT ON COLUMN qa_package_events.event_type IS 'Type of event that occurred';
+COMMENT ON COLUMN qa_package_events.event_data IS 'Additional event-specific data';

--- a/backend/src/main/resources/db/migration/V011__create_coverage_table.sql
+++ b/backend/src/main/resources/db/migration/V011__create_coverage_table.sql
@@ -1,0 +1,96 @@
+-- V011__create_coverage_table.sql
+-- Description: Create coverage tracking tables for per-operation metrics
+-- Author: Database Agent
+-- Date: 2026-01-25
+
+-- Coverage status enum
+CREATE TYPE coverage_status AS ENUM ('COVERED', 'FAILED', 'UNTESTED', 'SKIPPED');
+
+-- Coverage snapshots per QA package run
+CREATE TABLE coverage_snapshots (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    qa_package_id UUID NOT NULL REFERENCES qa_packages(id) ON DELETE CASCADE,
+    spec_hash VARCHAR(64) NOT NULL,
+
+    -- Summary metrics
+    operations_total INTEGER NOT NULL DEFAULT 0,
+    operations_covered INTEGER NOT NULL DEFAULT 0,
+    operations_failed INTEGER NOT NULL DEFAULT 0,
+    operations_untested INTEGER NOT NULL DEFAULT 0,
+    coverage_percent DECIMAL(5,2) DEFAULT 0.00,
+
+    -- Scenarios summary
+    scenarios_total INTEGER NOT NULL DEFAULT 0,
+    scenarios_passed INTEGER NOT NULL DEFAULT 0,
+    scenarios_failed INTEGER NOT NULL DEFAULT 0,
+
+    -- Gap analysis
+    gaps_json JSONB DEFAULT '[]',
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_coverage_percent_range CHECK (coverage_percent >= 0 AND coverage_percent <= 100),
+    CONSTRAINT chk_counts_positive CHECK (
+        operations_total >= 0 AND
+        operations_covered >= 0 AND
+        operations_failed >= 0 AND
+        operations_untested >= 0 AND
+        scenarios_total >= 0 AND
+        scenarios_passed >= 0 AND
+        scenarios_failed >= 0
+    ),
+    CONSTRAINT uq_package_snapshot UNIQUE (qa_package_id)
+);
+
+-- Per-operation coverage details
+CREATE TABLE operation_coverage (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    snapshot_id UUID NOT NULL REFERENCES coverage_snapshots(id) ON DELETE CASCADE,
+
+    -- Operation identification
+    operation_id VARCHAR(255) NOT NULL,
+    http_method VARCHAR(10) NOT NULL,
+    path VARCHAR(2048) NOT NULL,
+    summary VARCHAR(500),
+
+    -- Coverage status
+    status coverage_status NOT NULL DEFAULT 'UNTESTED',
+    scenarios_count INTEGER DEFAULT 0,
+    scenarios_passed INTEGER DEFAULT 0,
+    scenarios_failed INTEGER DEFAULT 0,
+
+    -- Quality metrics
+    has_weak_assertions BOOLEAN DEFAULT FALSE,
+    has_unresolved_placeholders BOOLEAN DEFAULT FALSE,
+
+    -- Related scenarios
+    scenario_ids UUID[] DEFAULT '{}',
+
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT chk_http_method CHECK (http_method IN ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')),
+    CONSTRAINT uq_snapshot_operation UNIQUE (snapshot_id, operation_id)
+);
+
+-- Indexes for coverage_snapshots
+CREATE INDEX idx_coverage_snapshots_package_id ON coverage_snapshots(qa_package_id);
+CREATE INDEX idx_coverage_snapshots_spec_hash ON coverage_snapshots(spec_hash);
+CREATE INDEX idx_coverage_snapshots_created_at ON coverage_snapshots(created_at DESC);
+
+-- Indexes for operation_coverage
+CREATE INDEX idx_operation_coverage_snapshot_id ON operation_coverage(snapshot_id);
+CREATE INDEX idx_operation_coverage_status ON operation_coverage(status);
+CREATE INDEX idx_operation_coverage_operation_id ON operation_coverage(operation_id);
+CREATE INDEX idx_operation_coverage_method_path ON operation_coverage(http_method, path);
+
+-- Partial indexes for gap detection
+CREATE INDEX idx_operation_coverage_untested ON operation_coverage(snapshot_id) WHERE status = 'UNTESTED';
+CREATE INDEX idx_operation_coverage_failed ON operation_coverage(snapshot_id) WHERE status = 'FAILED';
+CREATE INDEX idx_operation_coverage_weak ON operation_coverage(snapshot_id) WHERE has_weak_assertions = TRUE;
+
+-- Table comments
+COMMENT ON TABLE coverage_snapshots IS 'Coverage summary snapshots per QA package run';
+COMMENT ON COLUMN coverage_snapshots.gaps_json IS 'List of identified coverage gaps';
+COMMENT ON TABLE operation_coverage IS 'Per-operation coverage details within a snapshot';
+COMMENT ON COLUMN operation_coverage.has_weak_assertions IS 'Flag for scenarios with empty expected.bodyFields';
+COMMENT ON COLUMN operation_coverage.has_unresolved_placeholders IS 'Flag for unresolved {placeholder} values';


### PR DESCRIPTION
## Summary
- Create Flyway migration directory structure at `/backend/src/main/resources/db/migration/`
- Add 11 migration files covering the complete QAWave domain model
- Implement comprehensive schema with proper constraints, indexes, and documentation

## Migration Files Created

| File | Description |
|------|-------------|
| V001__initial_setup.sql | Extensions (uuid-ossp, pg_trgm), enums, update_updated_at function |
| V002__create_requirements_table.sql | Business requirements table |
| V003__create_api_specs_table.sql | OpenAPI specifications storage |
| V004__create_test_suites_table.sql | Test suite grouping |
| V005__create_test_scenarios_table.sql | Test scenarios with embedded steps_json |
| V006__create_test_runs_table.sql | Test execution instances |
| V007__create_test_step_results_table.sql | Per-step execution results |
| V008__create_qa_packages_table.sql | Main container for AI-powered test runs |
| V009__create_ai_logs_table.sql | AI interaction audit logs |
| V010__create_events_table.sql | QA package state transition events |
| V011__create_coverage_table.sql | Coverage tracking and gap analysis |

## Schema Features
- UUID primary keys with `uuid_generate_v4()`
- `pg_trgm` extension for full-text search on name fields
- Proper foreign key constraints with `ON DELETE CASCADE/SET NULL`
- Comprehensive indexes for common query patterns
- Partial indexes for status filtering and performance
- JSONB columns for flexible structured data
- Data validation constraints (URL format, non-empty strings, range checks)
- Automatic `updated_at` triggers
- Table and column comments for documentation

## Test plan
- [ ] Migrations run successfully on empty PostgreSQL 16 database
- [ ] All foreign key constraints work correctly
- [ ] Indexes created and used by common queries
- [ ] Enum types accept only valid values
- [ ] JSONB validation constraints work (steps_json structure)

Closes #10

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)