### PR TITLE
[DevOps] feat: K0s cluster bootstrap configuration (#4)

### DIFF
--- a/infrastructure/kubernetes/.gitignore
+++ b/infrastructure/kubernetes/.gitignore
@@ -1,0 +1,13 @@
+# K0s configuration with actual IPs
+k0s/k0sctl.yaml
+
+# Kubeconfig files
+kubeconfig*.yaml
+*.kubeconfig
+
+# Secrets
+*-secrets.yaml
+sealed-secrets/
+
+# Local testing
+.kube/

--- a/infrastructure/kubernetes/README.md
+++ b/infrastructure/kubernetes/README.md
@@ -1,0 +1,209 @@
+# QAWave Kubernetes Infrastructure
+
+Kubernetes manifests and cluster configuration for QAWave.
+
+## Directory Structure
+
+```
+kubernetes/
+├── k0s/                    # K0s cluster configuration
+│   ├── k0sctl.yaml.template  # Cluster config template
+│   └── bootstrap.sh         # Bootstrap automation script
+├── base/                   # Base Kubernetes manifests
+│   └── backend/            # Backend deployment
+├── overlays/               # Kustomize overlays (future)
+│   ├── staging/
+│   └── production/
+├── ingress/                # Ingress configuration
+└── README.md               # This file
+```
+
+## K0s Cluster Bootstrap
+
+### Prerequisites
+
+1. **k0sctl** - K0s cluster management tool
+   ```bash
+   # macOS
+   brew install k0sproject/tap/k0sctl
+
+   # Linux
+   curl -sSLf https://get.k0sproject.io | sudo sh
+   k0sctl version
+   ```
+
+2. **Terraform** applied - Infrastructure must be provisioned first
+   ```bash
+   cd ../terraform/environments/production
+   terraform apply
+   ```
+
+3. **SSH access** - Ensure your SSH key can access the Hetzner servers
+
+### Quick Start
+
+```bash
+cd k0s/
+
+# Automatic bootstrap (reads IPs from Terraform)
+./bootstrap.sh
+
+# Or dry-run first
+./bootstrap.sh --dry-run
+```
+
+### Manual Setup
+
+If you prefer manual setup:
+
+```bash
+# 1. Copy template
+cp k0sctl.yaml.template k0sctl.yaml
+
+# 2. Get IPs from Terraform
+cd ../../terraform/environments/production
+terraform output
+
+# 3. Edit k0sctl.yaml with the IPs
+
+# 4. Apply cluster
+k0sctl apply --config k0sctl.yaml
+
+# 5. Get kubeconfig
+k0sctl kubeconfig --config k0sctl.yaml > kubeconfig.yaml
+export KUBECONFIG=$(pwd)/kubeconfig.yaml
+
+# 6. Verify
+kubectl get nodes
+```
+
+## Cluster Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │    Load Balancer        │
+                    │    (Hetzner LB11)       │
+                    └───────────┬─────────────┘
+                                │
+            ┌───────────────────┼───────────────────┐
+            │                   │                   │
+            ▼                   ▼                   ▼
+   ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
+   │   Worker 1      │ │   Worker 2      │ │   Worker 3      │
+   │                 │ │                 │ │                 │
+   │ ┌─────────────┐ │ │ ┌─────────────┐ │ │ ┌─────────────┐ │
+   │ │ Ingress     │ │ │ │ Ingress     │ │ │ │ Ingress     │ │
+   │ │ Controller  │ │ │ │ Controller  │ │ │ │ Controller  │ │
+   │ │ (NodePort)  │ │ │ │ (NodePort)  │ │ │ │ (NodePort)  │ │
+   │ └─────────────┘ │ │ └─────────────┘ │ │ └─────────────┘ │
+   │                 │ │                 │ │                 │
+   │ ┌─────────────┐ │ │ ┌─────────────┐ │ │ ┌─────────────┐ │
+   │ │ App Pods    │ │ │ │ App Pods    │ │ │ │ App Pods    │ │
+   │ └─────────────┘ │ │ └─────────────┘ │ │ └─────────────┘ │
+   └─────────────────┘ └─────────────────┘ └─────────────────┘
+            │                   │                   │
+            └───────────────────┼───────────────────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │   Control Plane       │
+                    │   (K0s Controller)    │
+                    │   - API Server        │
+                    │   - etcd              │
+                    │   - Scheduler         │
+                    │   - Controller Mgr    │
+                    └───────────────────────┘
+```
+
+## Networking
+
+| Component | CIDR |
+|-----------|------|
+| Pod Network | 10.244.0.0/16 |
+| Service Network | 10.96.0.0/12 |
+| VPC Network | 10.0.0.0/16 |
+
+## Ingress
+
+The cluster uses nginx-ingress installed via Helm as a K0s extension:
+
+- **Type**: NodePort
+- **HTTP Port**: 30080
+- **HTTPS Port**: 30443
+
+The Hetzner Load Balancer forwards:
+- Port 80 → NodePort 30080
+- Port 443 → NodePort 30443
+
+## Common Commands
+
+```bash
+# Set kubeconfig
+export KUBECONFIG=/path/to/kubeconfig.yaml
+
+# Check nodes
+kubectl get nodes -o wide
+
+# Check all pods
+kubectl get pods -A
+
+# Check ingress
+kubectl get pods -n ingress-nginx
+kubectl get svc -n ingress-nginx
+
+# View logs
+kubectl logs -n kube-system deployment/coredns
+
+# Check cluster health
+kubectl cluster-info
+kubectl get componentstatuses
+```
+
+## Troubleshooting
+
+### Nodes not ready
+
+```bash
+# Check node conditions
+kubectl describe node <node-name>
+
+# Check kubelet logs (on the node)
+ssh root@<node-ip> journalctl -u k0sworker -f
+```
+
+### Ingress not working
+
+```bash
+# Check ingress controller pods
+kubectl get pods -n ingress-nginx
+
+# Check ingress controller logs
+kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller
+
+# Verify NodePort is accessible
+curl http://<worker-ip>:30080
+```
+
+### Reset cluster
+
+```bash
+# Remove cluster
+k0sctl reset --config k0sctl.yaml
+
+# Start fresh
+./bootstrap.sh
+```
+
+## Next Steps
+
+After cluster bootstrap:
+
+1. **Deploy ArgoCD**: `cd ../argocd && kubectl apply -f install/`
+2. **Deploy data services**: PostgreSQL, Redis, Kafka
+3. **Deploy applications**: Backend, Frontend via ArgoCD
+
+## Related Documentation
+
+- [K0s Documentation](https://docs.k0sproject.io/)
+- [k0sctl Reference](https://github.com/k0sproject/k0sctl)
+- [Terraform Configuration](../terraform/README.md)
+- [ArgoCD Setup](../argocd/README.md)

--- a/infrastructure/kubernetes/k0s/bootstrap.sh
+++ b/infrastructure/kubernetes/k0s/bootstrap.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# QAWave K0s Cluster Bootstrap Script
+# This script automates the K0s cluster setup using k0sctl
+#
+# Prerequisites:
+#   - k0sctl installed: https://github.com/k0sproject/k0sctl#installation
+#   - SSH key configured for Hetzner servers
+#   - Terraform has been applied and outputs are available
+#
+# Usage:
+#   ./bootstrap.sh [--dry-run]
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K0SCTL_CONFIG="${SCRIPT_DIR}/k0sctl.yaml"
+K0SCTL_TEMPLATE="${SCRIPT_DIR}/k0sctl.yaml.template"
+TERRAFORM_DIR="${SCRIPT_DIR}/../../terraform/environments/production"
+KUBECONFIG_OUTPUT="${SCRIPT_DIR}/kubeconfig.yaml"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+check_dependencies() {
+    log_info "Checking dependencies..."
+
+    if ! command -v k0sctl &> /dev/null; then
+        log_error "k0sctl is not installed. Install from: https://github.com/k0sproject/k0sctl#installation"
+        exit 1
+    fi
+
+    if ! command -v terraform &> /dev/null; then
+        log_error "terraform is not installed"
+        exit 1
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        log_error "jq is not installed"
+        exit 1
+    fi
+
+    log_info "All dependencies present"
+}
+
+get_terraform_outputs() {
+    log_info "Getting Terraform outputs..."
+
+    if [[ ! -d "${TERRAFORM_DIR}" ]]; then
+        log_error "Terraform directory not found: ${TERRAFORM_DIR}"
+        exit 1
+    fi
+
+    cd "${TERRAFORM_DIR}"
+
+    CONTROL_PLANE_IP=$(terraform output -raw control_plane_ip 2>/dev/null || echo "")
+    LOAD_BALANCER_IP=$(terraform output -raw load_balancer_ip 2>/dev/null || echo "")
+
+    # Get worker IPs as array
+    WORKER_IPS=$(terraform output -json worker_ips 2>/dev/null || echo "[]")
+    WORKER_1_IP=$(echo "${WORKER_IPS}" | jq -r '.[0] // empty')
+    WORKER_2_IP=$(echo "${WORKER_IPS}" | jq -r '.[1] // empty')
+    WORKER_3_IP=$(echo "${WORKER_IPS}" | jq -r '.[2] // empty')
+
+    if [[ -z "${CONTROL_PLANE_IP}" ]]; then
+        log_error "Could not get control_plane_ip from Terraform. Has infrastructure been provisioned?"
+        exit 1
+    fi
+
+    log_info "Control Plane IP: ${CONTROL_PLANE_IP}"
+    log_info "Load Balancer IP: ${LOAD_BALANCER_IP}"
+    log_info "Worker 1 IP: ${WORKER_1_IP}"
+    log_info "Worker 2 IP: ${WORKER_2_IP}"
+    log_info "Worker 3 IP: ${WORKER_3_IP}"
+
+    cd "${SCRIPT_DIR}"
+}
+
+generate_k0sctl_config() {
+    log_info "Generating k0sctl configuration..."
+
+    # Replace placeholders in template
+    sed -e "s/\${CONTROL_PLANE_IP}/${CONTROL_PLANE_IP}/g" \
+        -e "s/\${LOAD_BALANCER_IP}/${LOAD_BALANCER_IP}/g" \
+        -e "s/\${WORKER_1_IP}/${WORKER_1_IP}/g" \
+        -e "s/\${WORKER_2_IP}/${WORKER_2_IP}/g" \
+        -e "s/\${WORKER_3_IP}/${WORKER_3_IP}/g" \
+        "${K0SCTL_TEMPLATE}" > "${K0SCTL_CONFIG}"
+
+    log_info "Generated k0sctl.yaml"
+}
+
+apply_cluster() {
+    log_info "Applying K0s cluster configuration..."
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        log_warn "Dry run mode - would execute: k0sctl apply --config ${K0SCTL_CONFIG}"
+        return
+    fi
+
+    k0sctl apply --config "${K0SCTL_CONFIG}"
+
+    log_info "Cluster applied successfully"
+}
+
+get_kubeconfig() {
+    log_info "Retrieving kubeconfig..."
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        log_warn "Dry run mode - would execute: k0sctl kubeconfig --config ${K0SCTL_CONFIG}"
+        return
+    fi
+
+    k0sctl kubeconfig --config "${K0SCTL_CONFIG}" > "${KUBECONFIG_OUTPUT}"
+    chmod 600 "${KUBECONFIG_OUTPUT}"
+
+    log_info "Kubeconfig saved to ${KUBECONFIG_OUTPUT}"
+    log_info "To use: export KUBECONFIG=${KUBECONFIG_OUTPUT}"
+}
+
+verify_cluster() {
+    log_info "Verifying cluster health..."
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        log_warn "Dry run mode - skipping verification"
+        return
+    fi
+
+    export KUBECONFIG="${KUBECONFIG_OUTPUT}"
+
+    log_info "Cluster nodes:"
+    kubectl get nodes -o wide
+
+    log_info "System pods:"
+    kubectl get pods -n kube-system
+
+    log_info "Ingress controller status:"
+    kubectl get pods -n ingress-nginx
+
+    log_info "Cluster verification complete"
+}
+
+main() {
+    # Parse arguments
+    DRY_RUN=false
+    if [[ "${1:-}" == "--dry-run" ]]; then
+        DRY_RUN=true
+        log_warn "Running in dry-run mode"
+    fi
+
+    echo "======================================"
+    echo "QAWave K0s Cluster Bootstrap"
+    echo "======================================"
+    echo ""
+
+    check_dependencies
+    get_terraform_outputs
+    generate_k0sctl_config
+    apply_cluster
+    get_kubeconfig
+    verify_cluster
+
+    echo ""
+    echo "======================================"
+    log_info "Bootstrap complete!"
+    echo "======================================"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Set kubeconfig: export KUBECONFIG=${KUBECONFIG_OUTPUT}"
+    echo "  2. Verify cluster: kubectl get nodes"
+    echo "  3. Deploy ArgoCD: see ../argocd/README.md"
+}
+
+main "$@"

--- a/infrastructure/kubernetes/k0s/k0sctl.yaml.template
+++ b/infrastructure/kubernetes/k0s/k0sctl.yaml.template
@@ -1,0 +1,113 @@
+# QAWave K0s Cluster Configuration
+# Copy to k0sctl.yaml and fill in the IP addresses from Terraform output
+#
+# Usage:
+#   1. Copy this file: cp k0sctl.yaml.template k0sctl.yaml
+#   2. Fill in the IP addresses from `terraform output`
+#   3. Run: k0sctl apply --config k0sctl.yaml
+#
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: qawave-production
+spec:
+  hosts:
+    # Control Plane Node
+    - role: controller
+      ssh:
+        address: ${CONTROL_PLANE_IP}  # Replace with actual IP
+        user: root
+        port: 22
+        keyPath: ~/.ssh/id_rsa
+      installFlags:
+        - --enable-metrics-scraper
+
+    # Worker Nodes
+    - role: worker
+      ssh:
+        address: ${WORKER_1_IP}  # Replace with actual IP
+        user: root
+        port: 22
+        keyPath: ~/.ssh/id_rsa
+
+    - role: worker
+      ssh:
+        address: ${WORKER_2_IP}  # Replace with actual IP
+        user: root
+        port: 22
+        keyPath: ~/.ssh/id_rsa
+
+    - role: worker
+      ssh:
+        address: ${WORKER_3_IP}  # Replace with actual IP
+        user: root
+        port: 22
+        keyPath: ~/.ssh/id_rsa
+
+  k0s:
+    version: 1.29.2+k0s.0
+    dynamicConfig: false
+    config:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: qawave
+      spec:
+        api:
+          port: 6443
+          k0sApiPort: 9443
+          externalAddress: ${CONTROL_PLANE_IP}
+          sans:
+            - ${CONTROL_PLANE_IP}
+            - ${LOAD_BALANCER_IP}
+
+        network:
+          provider: calico
+          calico:
+            mode: vxlan
+            vxlanPort: 4789
+            vxlanVNI: 4096
+          podCIDR: 10.244.0.0/16
+          serviceCIDR: 10.96.0.0/12
+
+        storage:
+          type: etcd
+
+        telemetry:
+          enabled: false
+
+        extensions:
+          helm:
+            repositories:
+              - name: ingress-nginx
+                url: https://kubernetes.github.io/ingress-nginx
+              - name: prometheus-community
+                url: https://prometheus-community.github.io/helm-charts
+              - name: grafana
+                url: https://grafana.github.io/helm-charts
+            charts:
+              # Nginx Ingress Controller
+              - name: ingress-nginx
+                chartname: ingress-nginx/ingress-nginx
+                version: "4.9.1"
+                namespace: ingress-nginx
+                values: |
+                  controller:
+                    service:
+                      type: NodePort
+                      nodePorts:
+                        http: 30080
+                        https: 30443
+                    metrics:
+                      enabled: true
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                    config:
+                      use-forwarded-headers: "true"
+                      compute-full-forwarded-for: "true"
+                      use-proxy-protocol: "false"


### PR DESCRIPTION
## Summary
- Add K0s cluster bootstrap configuration and automation scripts
- Provides complete setup for bootstrapping K0s Kubernetes cluster on Hetzner infrastructure

## Changes

### k0sctl.yaml.template
- Complete K0s cluster configuration using k0sctl
- Single controller + 3 worker topology
- Calico CNI with VXLAN mode
- Pod CIDR: 10.244.0.0/16, Service CIDR: 10.96.0.0/12
- nginx-ingress pre-configured via Helm extension
  - NodePort 30080 (HTTP) and 30443 (HTTPS)

### bootstrap.sh
Automated bootstrap script that:
1. Checks dependencies (k0sctl, terraform, jq)
2. Retrieves IPs from Terraform outputs
3. Generates k0sctl.yaml from template
4. Applies cluster configuration
5. Retrieves and saves kubeconfig
6. Verifies cluster health

Supports `--dry-run` mode for safe testing.

### README.md
- Quick start guide
- Cluster architecture diagram
- Networking documentation
- Common kubectl commands
- Troubleshooting guide

## Acceptance Criteria
- [x] K0s cluster configuration defined
- [x] Worker nodes configuration included
- [x] kubectl access via generated kubeconfig
- [x] Shell scripts for automation
- [x] Ingress controller (nginx) pre-configured

## Test plan
- [ ] Run `./bootstrap.sh --dry-run` to verify script logic
- [ ] Verify template substitution works correctly
- [ ] Test on actual Hetzner infrastructure (after #2 is merged)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)