### PR TITLE
[QA] feat: Set up Playwright E2E testing framework (#22)

### DIFF
--- a/e2e-tests/.env.example
+++ b/e2e-tests/.env.example
@@ -1,0 +1,10 @@
+# QAWave E2E Tests Environment Configuration
+
+# Frontend URL (default: http://localhost:5173)
+BASE_URL=http://localhost:5173
+
+# Backend API URL (default: http://localhost:8080)
+API_URL=http://localhost:8080
+
+# CI mode (enables retries, parallel workers)
+# CI=true

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -1,0 +1,39 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Test results
+test-results/
+results/
+playwright-report/
+screenshots/
+videos/
+
+# Coverage
+coverage/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Debug logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Playwright
+/blob-report/
+/playwright/.cache/

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,0 +1,182 @@
+# QAWave E2E Tests
+
+End-to-end tests for the QAWave platform using Playwright.
+
+## Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+## Installation
+
+```bash
+cd e2e-tests
+npm install
+npx playwright install
+```
+
+## Running Tests
+
+### All tests
+
+```bash
+npm test
+```
+
+### With UI mode (interactive)
+
+```bash
+npm run test:ui
+```
+
+### Headed mode (see browser)
+
+```bash
+npm run test:headed
+```
+
+### Debug mode
+
+```bash
+npm run test:debug
+```
+
+### Smoke tests only
+
+```bash
+npm run test:smoke
+```
+
+### API tests only
+
+```bash
+npm run test:api
+```
+
+### Specific browser
+
+```bash
+npm run test:chromium
+npm run test:firefox
+npm run test:webkit
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BASE_URL` | `http://localhost:5173` | Frontend URL |
+| `API_URL` | `http://localhost:8080` | Backend API URL |
+| `CI` | - | Set to `true` in CI environment |
+
+### Running against different environments
+
+```bash
+# Local
+npm test
+
+# Staging
+BASE_URL=https://staging.qawave.io API_URL=https://api.staging.qawave.io npm test
+
+# Production (smoke tests only)
+BASE_URL=https://qawave.io API_URL=https://api.qawave.io npm run test:smoke
+```
+
+## Project Structure
+
+```
+e2e-tests/
+├── src/
+│   ├── fixtures/         # Test data and setup helpers
+│   ├── pages/            # Page Object Models
+│   ├── api/              # API client helpers
+│   ├── tests/            # Test specifications
+│   │   ├── smoke/        # Critical path tests
+│   │   ├── packages/     # Package feature tests
+│   │   ├── scenarios/    # Scenario feature tests
+│   │   └── api/          # Pure API tests
+│   └── utils/            # Utilities
+├── load-tests/           # k6 performance tests
+├── playwright.config.ts
+└── package.json
+```
+
+## Writing Tests
+
+### Page Object Model
+
+All page interactions should go through Page Object Models:
+
+```typescript
+import { PackagesPage } from '../../pages/PackagesPage';
+
+test('example test', async ({ page }) => {
+  const packagesPage = new PackagesPage(page);
+  await packagesPage.navigate();
+  await packagesPage.clickCreatePackage();
+});
+```
+
+### Test Data
+
+Use test data factories for consistent, realistic data:
+
+```typescript
+import { testData } from '../../fixtures/testData';
+
+const packageData = testData.createPackage();
+```
+
+### Cleanup
+
+Always clean up test data:
+
+```typescript
+import { cleanupPackage } from '../../fixtures/cleanup';
+
+test.afterEach(async () => {
+  if (createdPackageId) {
+    await cleanupPackage(createdPackageId);
+  }
+});
+```
+
+## CI Integration
+
+Tests run automatically in GitHub Actions when:
+
+- A PR is created
+- Code is pushed to main
+- Staging deployment completes
+
+## Reports
+
+View the HTML report:
+
+```bash
+npm run report
+```
+
+Reports are also available in CI artifacts.
+
+## Troubleshooting
+
+### Tests fail on CI but pass locally
+
+- Check environment variables
+- Verify network access to test endpoints
+- Check for timing issues (increase timeouts if needed)
+
+### Element not found errors
+
+- Verify test IDs match component implementation
+- Check if element is in viewport
+- Ensure page has fully loaded
+
+### Flaky tests
+
+- Use proper waits instead of arbitrary timeouts
+- Make tests independent and isolated
+- Clean up test data between runs

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "qawave-e2e-tests",
+  "version": "1.0.0",
+  "description": "End-to-end tests for QAWave platform",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "test:smoke": "playwright test --grep @smoke",
+    "test:api": "playwright test --project=api",
+    "test:chromium": "playwright test --project=chromium",
+    "test:firefox": "playwright test --project=firefox",
+    "test:webkit": "playwright test --project=webkit",
+    "report": "playwright show-report",
+    "codegen": "playwright codegen"
+  },
+  "keywords": [
+    "e2e",
+    "playwright",
+    "testing",
+    "qawave"
+  ],
+  "author": "QAWave Team",
+  "license": "MIT",
+  "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
+    "@playwright/test": "^1.44.0",
+    "@types/node": "^20.12.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -1,0 +1,106 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * QAWave Playwright Configuration
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './src/tests',
+
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+
+  /* Opt out of parallel tests on CI for stability */
+  workers: process.env.CI ? 4 : undefined,
+
+  /* Reporter to use */
+  reporter: [
+    ['html', { open: 'never' }],
+    ['junit', { outputFile: 'results/junit.xml' }],
+    ['list'],
+  ],
+
+  /* Shared settings for all the projects below */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')` */
+    baseURL: process.env.BASE_URL ?? 'http://localhost:5173',
+
+    /* API URL for backend tests */
+    extraHTTPHeaders: {
+      'Accept': 'application/json',
+    },
+
+    /* Collect trace when retrying the failed test */
+    trace: 'on-first-retry',
+
+    /* Take screenshot on failure */
+    screenshot: 'only-on-failure',
+
+    /* Record video on failure */
+    video: 'on-first-retry',
+
+    /* Maximum time each action can take */
+    actionTimeout: 15000,
+
+    /* Maximum time to wait for navigation */
+    navigationTimeout: 30000,
+  },
+
+  /* Global timeout for each test */
+  timeout: 60000,
+
+  /* Expect timeout */
+  expect: {
+    timeout: 10000,
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    /* Test against mobile viewports */
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 13'] },
+    },
+    /* API testing project */
+    {
+      name: 'api',
+      testDir: './src/tests/api',
+      use: {
+        baseURL: process.env.API_URL ?? 'http://localhost:8080',
+      },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: process.env.CI ? undefined : {
+    command: 'cd ../frontend && npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
+
+  /* Output folder for test artifacts */
+  outputDir: 'test-results/',
+});

--- a/e2e-tests/src/api/client.ts
+++ b/e2e-tests/src/api/client.ts
@@ -1,0 +1,103 @@
+import { APIRequestContext, APIResponse } from '@playwright/test';
+
+const API_URL = process.env.API_URL ?? 'http://localhost:8080';
+
+/**
+ * API response wrapper with typed body
+ */
+export interface ApiResponse<T> {
+  status: number;
+  body: T;
+  headers: Record<string, string>;
+  ok: boolean;
+}
+
+/**
+ * Base API client for backend communication
+ */
+export class ApiClient {
+  constructor(protected request: APIRequestContext) {}
+
+  /**
+   * Make GET request
+   */
+  async get<T>(path: string, options?: { params?: Record<string, string> }): Promise<ApiResponse<T>> {
+    const url = new URL(path, API_URL);
+    if (options?.params) {
+      Object.entries(options.params).forEach(([key, value]) => {
+        url.searchParams.append(key, value);
+      });
+    }
+
+    const response = await this.request.get(url.toString());
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Make POST request
+   */
+  async post<T>(path: string, data?: unknown): Promise<ApiResponse<T>> {
+    const response = await this.request.post(`${API_URL}${path}`, {
+      data,
+    });
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Make PUT request
+   */
+  async put<T>(path: string, data?: unknown): Promise<ApiResponse<T>> {
+    const response = await this.request.put(`${API_URL}${path}`, {
+      data,
+    });
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Make PATCH request
+   */
+  async patch<T>(path: string, data?: unknown): Promise<ApiResponse<T>> {
+    const response = await this.request.patch(`${API_URL}${path}`, {
+      data,
+    });
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Make DELETE request
+   */
+  async delete<T = void>(path: string): Promise<ApiResponse<T>> {
+    const response = await this.request.delete(`${API_URL}${path}`);
+    return this.parseResponse<T>(response);
+  }
+
+  /**
+   * Parse API response
+   */
+  private async parseResponse<T>(response: APIResponse): Promise<ApiResponse<T>> {
+    let body: T;
+    const contentType = response.headers()['content-type'] ?? '';
+
+    if (contentType.includes('application/json')) {
+      try {
+        body = await response.json();
+      } catch {
+        body = {} as T;
+      }
+    } else {
+      body = (await response.text()) as unknown as T;
+    }
+
+    const headers: Record<string, string> = {};
+    Object.entries(response.headers()).forEach(([key, value]) => {
+      headers[key] = value;
+    });
+
+    return {
+      status: response.status(),
+      body,
+      headers,
+      ok: response.ok(),
+    };
+  }
+}

--- a/e2e-tests/src/api/packages.api.ts
+++ b/e2e-tests/src/api/packages.api.ts
@@ -1,0 +1,91 @@
+import { APIRequestContext } from '@playwright/test';
+import { ApiClient, ApiResponse } from './client';
+
+/**
+ * Package entity type
+ */
+export interface Package {
+  id: string;
+  name: string;
+  specUrl: string;
+  baseUrl?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Create package request
+ */
+export interface CreatePackageRequest {
+  name?: string;
+  specUrl: string;
+  baseUrl?: string;
+  description?: string;
+}
+
+/**
+ * Paginated response
+ */
+export interface PagedResponse<T> {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+/**
+ * Packages API client
+ */
+export class PackagesApi extends ApiClient {
+  private readonly basePath = '/api/qa/packages';
+
+  constructor(request: APIRequestContext) {
+    super(request);
+  }
+
+  /**
+   * List all packages with pagination
+   */
+  async list(page = 0, size = 20): Promise<ApiResponse<PagedResponse<Package>>> {
+    return this.get<PagedResponse<Package>>(this.basePath, {
+      params: { page: page.toString(), size: size.toString() },
+    });
+  }
+
+  /**
+   * Get package by ID
+   */
+  async getById(id: string): Promise<ApiResponse<Package>> {
+    return this.get<Package>(`${this.basePath}/${id}`);
+  }
+
+  /**
+   * Create new package
+   */
+  async create(data: CreatePackageRequest): Promise<ApiResponse<Package>> {
+    return this.post<Package>(this.basePath, data);
+  }
+
+  /**
+   * Update package
+   */
+  async update(id: string, data: Partial<CreatePackageRequest>): Promise<ApiResponse<Package>> {
+    return this.put<Package>(`${this.basePath}/${id}`, data);
+  }
+
+  /**
+   * Delete package
+   */
+  async deletePackage(id: string): Promise<ApiResponse<void>> {
+    return this.delete(`${this.basePath}/${id}`);
+  }
+
+  /**
+   * Trigger test run for package
+   */
+  async triggerRun(packageId: string): Promise<ApiResponse<{ runId: string }>> {
+    return this.post<{ runId: string }>(`${this.basePath}/${packageId}/runs`);
+  }
+}

--- a/e2e-tests/src/api/scenarios.api.ts
+++ b/e2e-tests/src/api/scenarios.api.ts
@@ -1,0 +1,127 @@
+import { APIRequestContext } from '@playwright/test';
+import { ApiClient, ApiResponse } from './client';
+import { PagedResponse } from './packages.api';
+
+/**
+ * Scenario entity type
+ */
+export interface Scenario {
+  id: string;
+  packageId: string;
+  name: string;
+  description?: string;
+  steps: ScenarioStep[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Scenario step
+ */
+export interface ScenarioStep {
+  id: string;
+  name: string;
+  method: string;
+  path: string;
+  expectedStatus: number;
+  requestBody?: Record<string, unknown>;
+  assertions?: StepAssertion[];
+}
+
+/**
+ * Step assertion
+ */
+export interface StepAssertion {
+  type: 'status' | 'jsonPath' | 'header';
+  path?: string;
+  expected: unknown;
+}
+
+/**
+ * Create scenario request
+ */
+export interface CreateScenarioRequest {
+  name: string;
+  description?: string;
+  steps?: ScenarioStep[];
+}
+
+/**
+ * Scenarios API client
+ */
+export class ScenariosApi extends ApiClient {
+  private readonly basePath = '/api/qa/scenarios';
+
+  constructor(request: APIRequestContext) {
+    super(request);
+  }
+
+  /**
+   * List all scenarios
+   */
+  async list(page = 0, size = 20): Promise<ApiResponse<PagedResponse<Scenario>>> {
+    return this.get<PagedResponse<Scenario>>(this.basePath, {
+      params: { page: page.toString(), size: size.toString() },
+    });
+  }
+
+  /**
+   * List scenarios for a specific package
+   */
+  async listByPackage(
+    packageId: string,
+    page = 0,
+    size = 20
+  ): Promise<ApiResponse<PagedResponse<Scenario>>> {
+    return this.get<PagedResponse<Scenario>>(this.basePath, {
+      params: {
+        packageId,
+        page: page.toString(),
+        size: size.toString(),
+      },
+    });
+  }
+
+  /**
+   * Get scenario by ID
+   */
+  async getById(id: string): Promise<ApiResponse<Scenario>> {
+    return this.get<Scenario>(`${this.basePath}/${id}`);
+  }
+
+  /**
+   * Create new scenario
+   */
+  async create(
+    packageId: string,
+    data: CreateScenarioRequest
+  ): Promise<ApiResponse<Scenario>> {
+    return this.post<Scenario>(`/api/qa/packages/${packageId}/scenarios`, data);
+  }
+
+  /**
+   * Update scenario
+   */
+  async update(
+    id: string,
+    data: Partial<CreateScenarioRequest>
+  ): Promise<ApiResponse<Scenario>> {
+    return this.put<Scenario>(`${this.basePath}/${id}`, data);
+  }
+
+  /**
+   * Delete scenario
+   */
+  async deleteScenario(id: string): Promise<ApiResponse<void>> {
+    return this.delete(`${this.basePath}/${id}`);
+  }
+
+  /**
+   * Generate scenarios from OpenAPI spec
+   */
+  async generate(packageId: string): Promise<ApiResponse<{ count: number }>> {
+    return this.post<{ count: number }>(
+      `/api/qa/packages/${packageId}/scenarios/generate`
+    );
+  }
+}

--- a/e2e-tests/src/fixtures/auth.ts
+++ b/e2e-tests/src/fixtures/auth.ts
@@ -1,0 +1,76 @@
+import { Page, BrowserContext } from '@playwright/test';
+
+const API_URL = process.env.API_URL ?? 'http://localhost:8080';
+
+/**
+ * Authentication helpers for E2E tests
+ */
+
+export interface AuthCredentials {
+  email: string;
+  password: string;
+}
+
+/**
+ * Login via UI
+ */
+export async function loginViaUI(
+  page: Page,
+  credentials: AuthCredentials
+): Promise<void> {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(credentials.email);
+  await page.getByLabel('Password').fill(credentials.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('/');
+}
+
+/**
+ * Login via API and set cookies
+ */
+export async function loginViaAPI(
+  context: BrowserContext,
+  credentials: AuthCredentials
+): Promise<void> {
+  const response = await context.request.post(`${API_URL}/api/auth/login`, {
+    data: credentials,
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Login failed: ${response.status()}`);
+  }
+
+  // Cookies are automatically stored in the context
+}
+
+/**
+ * Logout via UI
+ */
+export async function logoutViaUI(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'User menu' }).click();
+  await page.getByRole('menuitem', { name: 'Sign out' }).click();
+  await page.waitForURL('/login');
+}
+
+/**
+ * Check if user is authenticated
+ */
+export async function isAuthenticated(page: Page): Promise<boolean> {
+  try {
+    // Check for user menu presence as indicator of auth state
+    const userMenu = page.getByRole('button', { name: 'User menu' });
+    return await userMenu.isVisible({ timeout: 1000 });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create authenticated browser context with stored auth state
+ */
+export async function createAuthenticatedContext(
+  context: BrowserContext,
+  credentials: AuthCredentials
+): Promise<void> {
+  await loginViaAPI(context, credentials);
+}

--- a/e2e-tests/src/fixtures/cleanup.ts
+++ b/e2e-tests/src/fixtures/cleanup.ts
@@ -1,0 +1,67 @@
+import { request } from '@playwright/test';
+
+const API_URL = process.env.API_URL ?? 'http://localhost:8080';
+
+/**
+ * Cleanup helper for test data management
+ * Ensures test isolation by removing created resources after tests
+ */
+
+/**
+ * Delete a QA package by ID
+ */
+export async function cleanupPackage(id: string): Promise<void> {
+  const context = await request.newContext({ baseURL: API_URL });
+  try {
+    await context.delete(`/api/qa/packages/${id}`);
+  } catch (error) {
+    console.warn(`Failed to cleanup package ${id}:`, error);
+  } finally {
+    await context.dispose();
+  }
+}
+
+/**
+ * Delete a scenario by ID
+ */
+export async function cleanupScenario(id: string): Promise<void> {
+  const context = await request.newContext({ baseURL: API_URL });
+  try {
+    await context.delete(`/api/qa/scenarios/${id}`);
+  } catch (error) {
+    console.warn(`Failed to cleanup scenario ${id}:`, error);
+  } finally {
+    await context.dispose();
+  }
+}
+
+/**
+ * Delete a test run by ID
+ */
+export async function cleanupTestRun(id: string): Promise<void> {
+  const context = await request.newContext({ baseURL: API_URL });
+  try {
+    await context.delete(`/api/qa/runs/${id}`);
+  } catch (error) {
+    console.warn(`Failed to cleanup test run ${id}:`, error);
+  } finally {
+    await context.dispose();
+  }
+}
+
+/**
+ * Bulk cleanup multiple resources
+ */
+export async function cleanupAll(resources: {
+  packages?: string[];
+  scenarios?: string[];
+  testRuns?: string[];
+}): Promise<void> {
+  const { packages = [], scenarios = [], testRuns = [] } = resources;
+
+  await Promise.all([
+    ...packages.map(cleanupPackage),
+    ...scenarios.map(cleanupScenario),
+    ...testRuns.map(cleanupTestRun),
+  ]);
+}

--- a/e2e-tests/src/fixtures/testData.ts
+++ b/e2e-tests/src/fixtures/testData.ts
@@ -1,0 +1,53 @@
+import { faker } from '@faker-js/faker';
+
+/**
+ * Test data factories for E2E tests
+ */
+export const testData = {
+  /**
+   * Generate test data for creating a QA package
+   */
+  createPackage: () => ({
+    name: `Test Package ${faker.string.alphanumeric(8)}`,
+    specUrl: 'https://petstore3.swagger.io/api/v3/openapi.json',
+    baseUrl: 'https://petstore3.swagger.io/api/v3',
+    description: faker.lorem.sentence(),
+  }),
+
+  /**
+   * Generate test data for creating a scenario
+   */
+  createScenario: () => ({
+    name: `Test Scenario ${faker.string.alphanumeric(8)}`,
+    description: faker.lorem.paragraph(),
+  }),
+
+  /**
+   * Generate unique email for test user
+   */
+  uniqueEmail: () =>
+    `test-${Date.now()}-${faker.string.alphanumeric(4)}@example.com`,
+
+  /**
+   * Generate test user data
+   */
+  createUser: () => ({
+    email: `test-${Date.now()}-${faker.string.alphanumeric(4)}@example.com`,
+    password: faker.internet.password({ length: 12 }),
+    name: faker.person.fullName(),
+  }),
+
+  /**
+   * Generate random test run configuration
+   */
+  createTestRunConfig: () => ({
+    environment: faker.helpers.arrayElement(['development', 'staging', 'production']),
+    parallelism: faker.number.int({ min: 1, max: 4 }),
+    retryCount: faker.number.int({ min: 0, max: 3 }),
+  }),
+};
+
+export type PackageData = ReturnType<typeof testData.createPackage>;
+export type ScenarioData = ReturnType<typeof testData.createScenario>;
+export type UserData = ReturnType<typeof testData.createUser>;
+export type TestRunConfig = ReturnType<typeof testData.createTestRunConfig>;

--- a/e2e-tests/src/pages/BasePage.ts
+++ b/e2e-tests/src/pages/BasePage.ts
@@ -1,0 +1,88 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Base page class with common functionality
+ * All page objects should extend this class
+ */
+export abstract class BasePage {
+  constructor(protected page: Page) {}
+
+  /**
+   * URL path for this page (override in subclass)
+   */
+  abstract readonly url: string;
+
+  /**
+   * Navigate to this page
+   */
+  async navigate(): Promise<void> {
+    await this.page.goto(this.url);
+  }
+
+  /**
+   * Wait for page to fully load
+   */
+  async waitForLoad(): Promise<void> {
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  /**
+   * Wait for element to be visible
+   */
+  async waitForElement(locator: Locator, timeout = 10000): Promise<void> {
+    await locator.waitFor({ state: 'visible', timeout });
+  }
+
+  /**
+   * Wait for element to be hidden
+   */
+  async waitForElementHidden(locator: Locator, timeout = 10000): Promise<void> {
+    await locator.waitFor({ state: 'hidden', timeout });
+  }
+
+  /**
+   * Get current page URL
+   */
+  async getCurrentUrl(): Promise<string> {
+    return this.page.url();
+  }
+
+  /**
+   * Get page title
+   */
+  async getTitle(): Promise<string> {
+    return this.page.title();
+  }
+
+  /**
+   * Take screenshot
+   */
+  async screenshot(name: string): Promise<void> {
+    await this.page.screenshot({ path: `screenshots/${name}.png` });
+  }
+
+  /**
+   * Wait for navigation to complete
+   */
+  async waitForNavigation(url?: string | RegExp): Promise<void> {
+    if (url) {
+      await this.page.waitForURL(url);
+    } else {
+      await this.page.waitForLoadState('load');
+    }
+  }
+
+  /**
+   * Check if element exists on page
+   */
+  async elementExists(locator: Locator): Promise<boolean> {
+    return (await locator.count()) > 0;
+  }
+
+  /**
+   * Scroll to element
+   */
+  async scrollToElement(locator: Locator): Promise<void> {
+    await locator.scrollIntoViewIfNeeded();
+  }
+}

--- a/e2e-tests/src/pages/LoginPage.ts
+++ b/e2e-tests/src/pages/LoginPage.ts
@@ -1,0 +1,88 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Login page object model
+ */
+export class LoginPage extends BasePage {
+  readonly url = '/login';
+
+  // Locators
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly signInButton: Locator;
+  readonly errorMessage: Locator;
+  readonly forgotPasswordLink: Locator;
+  readonly signUpLink: Locator;
+  readonly loadingSpinner: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.emailInput = page.getByLabel('Email');
+    this.passwordInput = page.getByLabel('Password');
+    this.signInButton = page.getByRole('button', { name: 'Sign in' });
+    this.errorMessage = page.getByRole('alert');
+    this.forgotPasswordLink = page.getByRole('link', { name: 'Forgot password?' });
+    this.signUpLink = page.getByRole('link', { name: 'Sign up' });
+    this.loadingSpinner = page.getByTestId('loading-spinner');
+  }
+
+  /**
+   * Fill login form with credentials
+   */
+  async fillCredentials(email: string, password: string): Promise<void> {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+  }
+
+  /**
+   * Submit login form
+   */
+  async submit(): Promise<void> {
+    await this.signInButton.click();
+  }
+
+  /**
+   * Complete login flow
+   */
+  async login(email: string, password: string): Promise<void> {
+    await this.fillCredentials(email, password);
+    await this.submit();
+  }
+
+  /**
+   * Wait for login to complete (redirect away from login page)
+   */
+  async waitForLoginComplete(): Promise<void> {
+    await this.page.waitForURL((url) => !url.pathname.includes('/login'));
+  }
+
+  /**
+   * Get error message text
+   */
+  async getErrorMessage(): Promise<string> {
+    await this.errorMessage.waitFor({ state: 'visible' });
+    return this.errorMessage.textContent() as Promise<string>;
+  }
+
+  /**
+   * Check if login form is visible
+   */
+  async isFormVisible(): Promise<boolean> {
+    return this.signInButton.isVisible();
+  }
+
+  /**
+   * Navigate to forgot password page
+   */
+  async goToForgotPassword(): Promise<void> {
+    await this.forgotPasswordLink.click();
+  }
+
+  /**
+   * Navigate to sign up page
+   */
+  async goToSignUp(): Promise<void> {
+    await this.signUpLink.click();
+  }
+}

--- a/e2e-tests/src/pages/PackageDetailPage.ts
+++ b/e2e-tests/src/pages/PackageDetailPage.ts
@@ -1,0 +1,145 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Package detail page object model
+ */
+export class PackageDetailPage extends BasePage {
+  readonly url = '/packages'; // Will be /packages/:id
+
+  // Locators
+  readonly packageName: Locator;
+  readonly packageDescription: Locator;
+  readonly specUrl: Locator;
+  readonly baseUrl: Locator;
+  readonly editButton: Locator;
+  readonly deleteButton: Locator;
+  readonly runTestsButton: Locator;
+  readonly scenariosList: Locator;
+  readonly scenarioCards: Locator;
+  readonly recentRuns: Locator;
+  readonly loadingSpinner: Locator;
+  readonly backButton: Locator;
+  readonly tabScenarios: Locator;
+  readonly tabRuns: Locator;
+  readonly tabSettings: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.packageName = page.getByTestId('package-name');
+    this.packageDescription = page.getByTestId('package-description');
+    this.specUrl = page.getByTestId('spec-url');
+    this.baseUrl = page.getByTestId('base-url');
+    this.editButton = page.getByRole('button', { name: 'Edit' });
+    this.deleteButton = page.getByRole('button', { name: 'Delete' });
+    this.runTestsButton = page.getByRole('button', { name: 'Run Tests' });
+    this.scenariosList = page.getByTestId('scenarios-list');
+    this.scenarioCards = page.getByTestId('scenario-card');
+    this.recentRuns = page.getByTestId('recent-runs');
+    this.loadingSpinner = page.getByTestId('loading-spinner');
+    this.backButton = page.getByRole('button', { name: 'Back' });
+    this.tabScenarios = page.getByRole('tab', { name: 'Scenarios' });
+    this.tabRuns = page.getByRole('tab', { name: 'Runs' });
+    this.tabSettings = page.getByRole('tab', { name: 'Settings' });
+  }
+
+  /**
+   * Navigate to specific package by ID
+   */
+  async navigateToPackage(packageId: string): Promise<void> {
+    await this.page.goto(`/packages/${packageId}`);
+  }
+
+  /**
+   * Wait for package details to load
+   */
+  async waitForLoad(): Promise<void> {
+    await this.loadingSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+  }
+
+  /**
+   * Get package name text
+   */
+  async getName(): Promise<string> {
+    return this.packageName.textContent() as Promise<string>;
+  }
+
+  /**
+   * Get package description text
+   */
+  async getDescription(): Promise<string> {
+    return this.packageDescription.textContent() as Promise<string>;
+  }
+
+  /**
+   * Click run tests button
+   */
+  async runTests(): Promise<void> {
+    await this.runTestsButton.click();
+  }
+
+  /**
+   * Click edit button
+   */
+  async edit(): Promise<void> {
+    await this.editButton.click();
+  }
+
+  /**
+   * Click delete button
+   */
+  async clickDelete(): Promise<void> {
+    await this.deleteButton.click();
+  }
+
+  /**
+   * Get scenario count
+   */
+  async getScenarioCount(): Promise<number> {
+    return this.scenarioCards.count();
+  }
+
+  /**
+   * Select a scenario by name
+   */
+  async selectScenario(name: string): Promise<void> {
+    await this.scenarioCards.filter({ hasText: name }).click();
+  }
+
+  /**
+   * Navigate to scenarios tab
+   */
+  async goToScenariosTab(): Promise<void> {
+    await this.tabScenarios.click();
+  }
+
+  /**
+   * Navigate to runs tab
+   */
+  async goToRunsTab(): Promise<void> {
+    await this.tabRuns.click();
+  }
+
+  /**
+   * Navigate to settings tab
+   */
+  async goToSettingsTab(): Promise<void> {
+    await this.tabSettings.click();
+  }
+
+  /**
+   * Go back to packages list
+   */
+  async goBack(): Promise<void> {
+    await this.backButton.click();
+  }
+
+  /**
+   * Get package ID from URL
+   */
+  async getPackageIdFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/packages\/([^/?]+)/);
+    return match ? match[1] : '';
+  }
+}

--- a/e2e-tests/src/pages/PackagesPage.ts
+++ b/e2e-tests/src/pages/PackagesPage.ts
@@ -1,0 +1,127 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Packages list page object model
+ */
+export class PackagesPage extends BasePage {
+  readonly url = '/packages';
+
+  // Locators
+  readonly createButton: Locator;
+  readonly packageCards: Locator;
+  readonly searchInput: Locator;
+  readonly loadingSpinner: Locator;
+  readonly emptyState: Locator;
+  readonly errorMessage: Locator;
+  readonly refreshButton: Locator;
+  readonly filterDropdown: Locator;
+  readonly pagination: Locator;
+  readonly sortDropdown: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.createButton = page.getByRole('button', { name: 'Create Package' });
+    this.packageCards = page.getByTestId('package-card');
+    this.searchInput = page.getByPlaceholder('Search packages...');
+    this.loadingSpinner = page.getByTestId('loading-spinner');
+    this.emptyState = page.getByTestId('empty-state');
+    this.errorMessage = page.getByRole('alert');
+    this.refreshButton = page.getByRole('button', { name: 'Refresh' });
+    this.filterDropdown = page.getByTestId('filter-dropdown');
+    this.pagination = page.getByTestId('pagination');
+    this.sortDropdown = page.getByTestId('sort-dropdown');
+  }
+
+  /**
+   * Wait for packages to finish loading
+   */
+  async waitForPackagesLoaded(): Promise<void> {
+    await this.loadingSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+  }
+
+  /**
+   * Get count of visible package cards
+   */
+  async getPackageCount(): Promise<number> {
+    await this.waitForPackagesLoaded();
+    return this.packageCards.count();
+  }
+
+  /**
+   * Click create package button
+   */
+  async clickCreatePackage(): Promise<void> {
+    await this.createButton.click();
+  }
+
+  /**
+   * Search for packages by name
+   */
+  async searchPackages(query: string): Promise<void> {
+    await this.searchInput.fill(query);
+    await this.page.keyboard.press('Enter');
+    await this.waitForPackagesLoaded();
+  }
+
+  /**
+   * Clear search input
+   */
+  async clearSearch(): Promise<void> {
+    await this.searchInput.clear();
+    await this.page.keyboard.press('Enter');
+    await this.waitForPackagesLoaded();
+  }
+
+  /**
+   * Select a package by name
+   */
+  async selectPackage(name: string): Promise<void> {
+    await this.packageCards.filter({ hasText: name }).click();
+  }
+
+  /**
+   * Get package card by index
+   */
+  getPackageCardByIndex(index: number): Locator {
+    return this.packageCards.nth(index);
+  }
+
+  /**
+   * Get package names from visible cards
+   */
+  async getPackageNames(): Promise<string[]> {
+    await this.waitForPackagesLoaded();
+    const cards = await this.packageCards.all();
+    const names: string[] = [];
+    for (const card of cards) {
+      const nameElement = card.getByTestId('package-name');
+      const name = await nameElement.textContent();
+      if (name) names.push(name);
+    }
+    return names;
+  }
+
+  /**
+   * Check if empty state is displayed
+   */
+  async isEmptyStateVisible(): Promise<boolean> {
+    return this.emptyState.isVisible();
+  }
+
+  /**
+   * Refresh the packages list
+   */
+  async refresh(): Promise<void> {
+    await this.refreshButton.click();
+    await this.waitForPackagesLoaded();
+  }
+
+  /**
+   * Check if package with name exists
+   */
+  async packageExists(name: string): Promise<boolean> {
+    const names = await this.getPackageNames();
+    return names.includes(name);
+  }
+}

--- a/e2e-tests/src/pages/RunDetailPage.ts
+++ b/e2e-tests/src/pages/RunDetailPage.ts
@@ -1,0 +1,153 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Test run detail page object model
+ */
+export class RunDetailPage extends BasePage {
+  readonly url = '/runs'; // Will be /runs/:id
+
+  // Locators
+  readonly runStatus: Locator;
+  readonly runDuration: Locator;
+  readonly runStartTime: Locator;
+  readonly runEndTime: Locator;
+  readonly testResults: Locator;
+  readonly passedTests: Locator;
+  readonly failedTests: Locator;
+  readonly skippedTests: Locator;
+  readonly progressBar: Locator;
+  readonly loadingSpinner: Locator;
+  readonly backButton: Locator;
+  readonly rerunButton: Locator;
+  readonly downloadReportButton: Locator;
+  readonly testCaseList: Locator;
+  readonly testCaseRows: Locator;
+  readonly errorDetails: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.runStatus = page.getByTestId('run-status');
+    this.runDuration = page.getByTestId('run-duration');
+    this.runStartTime = page.getByTestId('run-start-time');
+    this.runEndTime = page.getByTestId('run-end-time');
+    this.testResults = page.getByTestId('test-results');
+    this.passedTests = page.getByTestId('passed-count');
+    this.failedTests = page.getByTestId('failed-count');
+    this.skippedTests = page.getByTestId('skipped-count');
+    this.progressBar = page.getByTestId('progress-bar');
+    this.loadingSpinner = page.getByTestId('loading-spinner');
+    this.backButton = page.getByRole('button', { name: 'Back' });
+    this.rerunButton = page.getByRole('button', { name: 'Re-run' });
+    this.downloadReportButton = page.getByRole('button', { name: 'Download Report' });
+    this.testCaseList = page.getByTestId('test-case-list');
+    this.testCaseRows = page.getByTestId('test-case-row');
+    this.errorDetails = page.getByTestId('error-details');
+  }
+
+  /**
+   * Navigate to specific run by ID
+   */
+  async navigateToRun(runId: string): Promise<void> {
+    await this.page.goto(`/runs/${runId}`);
+  }
+
+  /**
+   * Wait for run details to load
+   */
+  async waitForLoad(): Promise<void> {
+    await this.loadingSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+  }
+
+  /**
+   * Get run status text
+   */
+  async getStatus(): Promise<string> {
+    return this.runStatus.textContent() as Promise<string>;
+  }
+
+  /**
+   * Get passed test count
+   */
+  async getPassedCount(): Promise<number> {
+    const text = await this.passedTests.textContent();
+    return parseInt(text || '0', 10);
+  }
+
+  /**
+   * Get failed test count
+   */
+  async getFailedCount(): Promise<number> {
+    const text = await this.failedTests.textContent();
+    return parseInt(text || '0', 10);
+  }
+
+  /**
+   * Get skipped test count
+   */
+  async getSkippedCount(): Promise<number> {
+    const text = await this.skippedTests.textContent();
+    return parseInt(text || '0', 10);
+  }
+
+  /**
+   * Get total test count
+   */
+  async getTotalCount(): Promise<number> {
+    return this.testCaseRows.count();
+  }
+
+  /**
+   * Wait for run to complete (status changes from running)
+   */
+  async waitForRunComplete(timeout = 300000): Promise<void> {
+    await expect(this.runStatus).not.toHaveText('Running', { timeout });
+  }
+
+  /**
+   * Click re-run button
+   */
+  async rerun(): Promise<void> {
+    await this.rerunButton.click();
+  }
+
+  /**
+   * Click download report button
+   */
+  async downloadReport(): Promise<void> {
+    await this.downloadReportButton.click();
+  }
+
+  /**
+   * Get failed test details
+   */
+  async getFailedTestDetails(): Promise<string[]> {
+    const failedRows = this.testCaseRows.filter({
+      has: this.page.locator('[data-status="failed"]'),
+    });
+    const count = await failedRows.count();
+    const details: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const row = failedRows.nth(i);
+      const text = await row.textContent();
+      if (text) details.push(text);
+    }
+    return details;
+  }
+
+  /**
+   * Go back to previous page
+   */
+  async goBack(): Promise<void> {
+    await this.backButton.click();
+  }
+
+  /**
+   * Get run ID from URL
+   */
+  async getRunIdFromUrl(): Promise<string> {
+    const url = this.page.url();
+    const match = url.match(/\/runs\/([^/?]+)/);
+    return match ? match[1] : '';
+  }
+}

--- a/e2e-tests/src/pages/index.ts
+++ b/e2e-tests/src/pages/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Page Object Models barrel export
+ */
+export { BasePage } from './BasePage';
+export { LoginPage } from './LoginPage';
+export { PackagesPage } from './PackagesPage';
+export { PackageDetailPage } from './PackageDetailPage';
+export { RunDetailPage } from './RunDetailPage';

--- a/e2e-tests/src/tests/api/packages.api.spec.ts
+++ b/e2e-tests/src/tests/api/packages.api.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+import { PackagesApi, Package, CreatePackageRequest } from '../../api/packages.api';
+import { testData } from '../../fixtures/testData';
+
+/**
+ * API tests for Packages endpoints
+ * These tests verify the backend API contract
+ */
+test.describe('Packages API @api', () => {
+  let api: PackagesApi;
+  let createdPackageIds: string[] = [];
+
+  test.beforeAll(async ({ request }) => {
+    api = new PackagesApi(request);
+  });
+
+  test.afterAll(async () => {
+    // Cleanup all created packages
+    for (const id of createdPackageIds) {
+      try {
+        await api.deletePackage(id);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  test('GET /api/qa/packages should return paginated list', async () => {
+    const response = await api.list();
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('content');
+    expect(response.body).toHaveProperty('totalElements');
+    expect(response.body).toHaveProperty('totalPages');
+    expect(response.body).toHaveProperty('size');
+    expect(response.body).toHaveProperty('number');
+    expect(Array.isArray(response.body.content)).toBe(true);
+  });
+
+  test('GET /api/qa/packages should support pagination params', async () => {
+    const response = await api.list(0, 5);
+
+    expect(response.status).toBe(200);
+    expect(response.body.size).toBe(5);
+    expect(response.body.number).toBe(0);
+  });
+
+  test('POST /api/qa/packages should create package with valid data', async () => {
+    const data = testData.createPackage();
+    const response = await api.create(data);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toHaveProperty('id');
+    expect(response.body.specUrl).toBe(data.specUrl);
+    expect(response.body.name).toBe(data.name);
+    expect(response.body).toHaveProperty('createdAt');
+
+    // Store for cleanup
+    createdPackageIds.push(response.body.id);
+  });
+
+  test('POST /api/qa/packages should validate required fields', async () => {
+    const response = await api.create({ specUrl: '' } as CreatePackageRequest);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('message');
+  });
+
+  test('POST /api/qa/packages should validate URL format', async () => {
+    const response = await api.create({
+      specUrl: 'not-a-valid-url',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  test('GET /api/qa/packages/:id should return package by ID', async () => {
+    // First create a package
+    const createData = testData.createPackage();
+    const createResponse = await api.create(createData);
+    expect(createResponse.status).toBe(201);
+    createdPackageIds.push(createResponse.body.id);
+
+    // Then fetch it
+    const response = await api.getById(createResponse.body.id);
+
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe(createResponse.body.id);
+    expect(response.body.specUrl).toBe(createData.specUrl);
+  });
+
+  test('GET /api/qa/packages/:id should return 404 for non-existent', async () => {
+    const response = await api.getById('non-existent-id');
+
+    expect(response.status).toBe(404);
+  });
+
+  test('PUT /api/qa/packages/:id should update package', async () => {
+    // First create a package
+    const createData = testData.createPackage();
+    const createResponse = await api.create(createData);
+    expect(createResponse.status).toBe(201);
+    createdPackageIds.push(createResponse.body.id);
+
+    // Update it
+    const newDescription = 'Updated description';
+    const updateResponse = await api.update(createResponse.body.id, {
+      description: newDescription,
+    });
+
+    expect(updateResponse.status).toBe(200);
+    expect(updateResponse.body.description).toBe(newDescription);
+    expect(updateResponse.body.specUrl).toBe(createData.specUrl);
+  });
+
+  test('DELETE /api/qa/packages/:id should delete package', async () => {
+    // First create a package
+    const createData = testData.createPackage();
+    const createResponse = await api.create(createData);
+    expect(createResponse.status).toBe(201);
+
+    // Delete it
+    const deleteResponse = await api.deletePackage(createResponse.body.id);
+    expect(deleteResponse.status).toBe(204);
+
+    // Verify it's gone
+    const getResponse = await api.getById(createResponse.body.id);
+    expect(getResponse.status).toBe(404);
+  });
+
+  test('DELETE /api/qa/packages/:id should return 404 for non-existent', async () => {
+    const response = await api.deletePackage('non-existent-id');
+
+    expect(response.status).toBe(404);
+  });
+
+  test('POST /api/qa/packages/:id/runs should trigger test run', async () => {
+    // First create a package
+    const createData = testData.createPackage();
+    const createResponse = await api.create(createData);
+    expect(createResponse.status).toBe(201);
+    createdPackageIds.push(createResponse.body.id);
+
+    // Trigger run
+    const runResponse = await api.triggerRun(createResponse.body.id);
+
+    expect(runResponse.status).toBe(202);
+    expect(runResponse.body).toHaveProperty('runId');
+  });
+});

--- a/e2e-tests/src/tests/smoke/smoke.spec.ts
+++ b/e2e-tests/src/tests/smoke/smoke.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+import { PackagesPage } from '../../pages/PackagesPage';
+import { PackageDetailPage } from '../../pages/PackageDetailPage';
+import { testData } from '../../fixtures/testData';
+import { cleanupPackage } from '../../fixtures/cleanup';
+
+/**
+ * Smoke tests for QAWave critical paths
+ * These tests verify the most important user journeys work correctly
+ *
+ * @tags @smoke
+ */
+test.describe('Smoke Tests @smoke', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let createdPackageId: string | null = null;
+
+  test.afterAll(async () => {
+    // Cleanup any created test data
+    if (createdPackageId) {
+      await cleanupPackage(createdPackageId);
+    }
+  });
+
+  test('application loads successfully', async ({ page }) => {
+    // Navigate to home page
+    await page.goto('/');
+
+    // Verify the page loads without errors
+    await expect(page).toHaveTitle(/QAWave/);
+
+    // Verify main navigation is visible
+    const nav = page.getByRole('navigation');
+    await expect(nav).toBeVisible();
+  });
+
+  test('can navigate to packages list', async ({ page }) => {
+    const packagesPage = new PackagesPage(page);
+
+    // Navigate to packages page
+    await packagesPage.navigate();
+
+    // Verify URL
+    await expect(page).toHaveURL(/\/packages/);
+
+    // Verify create button is visible
+    await expect(packagesPage.createButton).toBeVisible();
+
+    // Verify search input is visible
+    await expect(packagesPage.searchInput).toBeVisible();
+  });
+
+  test('can create a new QA package', async ({ page }) => {
+    const packagesPage = new PackagesPage(page);
+    const packageData = testData.createPackage();
+
+    // Navigate to packages
+    await packagesPage.navigate();
+    await packagesPage.waitForPackagesLoaded();
+
+    // Click create button
+    await packagesPage.clickCreatePackage();
+
+    // Fill in package details in modal
+    const modal = page.getByRole('dialog');
+    await expect(modal).toBeVisible();
+
+    // Fill form fields
+    await modal.getByLabel('Name').fill(packageData.name);
+    await modal.getByLabel('Spec URL').fill(packageData.specUrl);
+
+    if (packageData.baseUrl) {
+      await modal.getByLabel('Base URL').fill(packageData.baseUrl);
+    }
+
+    if (packageData.description) {
+      await modal.getByLabel('Description').fill(packageData.description);
+    }
+
+    // Submit form
+    await modal.getByRole('button', { name: 'Create' }).click();
+
+    // Wait for navigation to package detail page
+    await expect(page).toHaveURL(/\/packages\/[\w-]+/);
+
+    // Store package ID for cleanup
+    const url = page.url();
+    const match = url.match(/\/packages\/([\w-]+)/);
+    createdPackageId = match ? match[1] : null;
+
+    // Verify package name is displayed
+    await expect(page.getByText(packageData.name)).toBeVisible();
+  });
+
+  test('can view package details', async ({ page }) => {
+    test.skip(!createdPackageId, 'No package created in previous test');
+
+    const detailPage = new PackageDetailPage(page);
+
+    // Navigate to package detail
+    await detailPage.navigateToPackage(createdPackageId!);
+    await detailPage.waitForLoad();
+
+    // Verify package details are displayed
+    await expect(detailPage.packageName).toBeVisible();
+    await expect(detailPage.specUrl).toBeVisible();
+
+    // Verify action buttons are available
+    await expect(detailPage.editButton).toBeVisible();
+    await expect(detailPage.runTestsButton).toBeVisible();
+  });
+
+  test('can trigger a test run', async ({ page }) => {
+    test.skip(!createdPackageId, 'No package created in previous test');
+
+    const detailPage = new PackageDetailPage(page);
+
+    // Navigate to package detail
+    await detailPage.navigateToPackage(createdPackageId!);
+    await detailPage.waitForLoad();
+
+    // Click run tests button
+    await detailPage.runTests();
+
+    // Wait for run to start - should navigate to run detail or show status
+    await page.waitForResponse(
+      (response) =>
+        response.url().includes('/runs') && response.status() < 400,
+      { timeout: 30000 }
+    );
+
+    // Verify run was initiated (either navigate to run page or see status update)
+    const runIndicator = page
+      .getByTestId('run-status')
+      .or(page.getByText(/running|queued/i));
+    await expect(runIndicator).toBeVisible({ timeout: 10000 });
+  });
+
+  test('can view run results', async ({ page }) => {
+    test.skip(!createdPackageId, 'No package created in previous test');
+
+    const detailPage = new PackageDetailPage(page);
+
+    // Navigate to package detail
+    await detailPage.navigateToPackage(createdPackageId!);
+    await detailPage.waitForLoad();
+
+    // Go to runs tab
+    await detailPage.goToRunsTab();
+
+    // Verify runs list is visible
+    const runsList = page.getByTestId('runs-list').or(page.getByRole('table'));
+    await expect(runsList).toBeVisible({ timeout: 10000 });
+
+    // Should have at least one run from previous test
+    const runRows = page.getByTestId('run-row').or(page.getByRole('row'));
+    await expect(runRows.first()).toBeVisible();
+  });
+});

--- a/e2e-tests/src/utils/assertions.ts
+++ b/e2e-tests/src/utils/assertions.ts
@@ -1,0 +1,112 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+/**
+ * Custom assertion helpers for E2E tests
+ */
+
+/**
+ * Assert element is visible and contains text
+ */
+export async function assertVisibleWithText(
+  locator: Locator,
+  expectedText: string
+): Promise<void> {
+  await expect(locator).toBeVisible();
+  await expect(locator).toContainText(expectedText);
+}
+
+/**
+ * Assert element count
+ */
+export async function assertCount(
+  locator: Locator,
+  expectedCount: number
+): Promise<void> {
+  await expect(locator).toHaveCount(expectedCount);
+}
+
+/**
+ * Assert URL matches pattern
+ */
+export async function assertUrl(
+  page: Page,
+  urlPattern: string | RegExp
+): Promise<void> {
+  await expect(page).toHaveURL(urlPattern);
+}
+
+/**
+ * Assert toast notification appears
+ */
+export async function assertToast(
+  page: Page,
+  message: string,
+  type?: 'success' | 'error' | 'warning' | 'info'
+): Promise<void> {
+  const toast = page.getByRole('alert');
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText(message);
+
+  if (type) {
+    await expect(toast).toHaveAttribute('data-type', type);
+  }
+}
+
+/**
+ * Assert form validation error
+ */
+export async function assertValidationError(
+  locator: Locator,
+  errorMessage: string
+): Promise<void> {
+  await expect(locator).toBeVisible();
+  await expect(locator).toHaveText(errorMessage);
+}
+
+/**
+ * Assert page title
+ */
+export async function assertTitle(
+  page: Page,
+  expectedTitle: string
+): Promise<void> {
+  await expect(page).toHaveTitle(expectedTitle);
+}
+
+/**
+ * Assert element has specific CSS class
+ */
+export async function assertHasClass(
+  locator: Locator,
+  className: string
+): Promise<void> {
+  await expect(locator).toHaveClass(new RegExp(className));
+}
+
+/**
+ * Assert element is disabled
+ */
+export async function assertDisabled(locator: Locator): Promise<void> {
+  await expect(locator).toBeDisabled();
+}
+
+/**
+ * Assert element is enabled
+ */
+export async function assertEnabled(locator: Locator): Promise<void> {
+  await expect(locator).toBeEnabled();
+}
+
+/**
+ * Assert API response status and body
+ */
+export function assertApiResponse<T>(
+  response: { status: number; body: T },
+  expectedStatus: number,
+  bodyValidator?: (body: T) => boolean
+): void {
+  expect(response.status).toBe(expectedStatus);
+  if (bodyValidator) {
+    expect(bodyValidator(response.body)).toBe(true);
+  }
+}

--- a/e2e-tests/src/utils/reporters.ts
+++ b/e2e-tests/src/utils/reporters.ts
@@ -1,0 +1,96 @@
+import { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter';
+
+/**
+ * Custom reporter utilities for QAWave E2E tests
+ */
+
+/**
+ * Console summary reporter
+ */
+export class ConsoleSummaryReporter implements Reporter {
+  private passed = 0;
+  private failed = 0;
+  private skipped = 0;
+  private startTime: number = 0;
+
+  onBegin(): void {
+    this.startTime = Date.now();
+    console.log('\n========================================');
+    console.log('  QAWave E2E Test Suite');
+    console.log('========================================\n');
+  }
+
+  onTestEnd(test: TestCase, result: TestResult): void {
+    const status = result.status;
+    const icon = status === 'passed' ? '✓' : status === 'failed' ? '✗' : '○';
+
+    if (status === 'passed') {
+      this.passed++;
+      console.log(`  ${icon} ${test.title}`);
+    } else if (status === 'failed') {
+      this.failed++;
+      console.log(`  ${icon} ${test.title}`);
+      if (result.error) {
+        console.log(`    Error: ${result.error.message}`);
+      }
+    } else {
+      this.skipped++;
+      console.log(`  ${icon} ${test.title} (skipped)`);
+    }
+  }
+
+  onEnd(result: FullResult): void {
+    const duration = ((Date.now() - this.startTime) / 1000).toFixed(2);
+    const total = this.passed + this.failed + this.skipped;
+
+    console.log('\n----------------------------------------');
+    console.log(`  Results: ${this.passed}/${total} passed`);
+    console.log(`  Duration: ${duration}s`);
+    console.log(`  Status: ${result.status}`);
+    console.log('----------------------------------------\n');
+  }
+}
+
+/**
+ * Format test duration in human readable format
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  } else if (ms < 60000) {
+    return `${(ms / 1000).toFixed(2)}s`;
+  } else {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = ((ms % 60000) / 1000).toFixed(0);
+    return `${minutes}m ${seconds}s`;
+  }
+}
+
+/**
+ * Generate test summary object
+ */
+export interface TestSummary {
+  total: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  duration: number;
+  passRate: number;
+}
+
+export function generateSummary(results: TestResult[]): TestSummary {
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const skipped = results.filter((r) => r.status === 'skipped').length;
+  const total = results.length;
+  const duration = results.reduce((acc, r) => acc + r.duration, 0);
+
+  return {
+    total,
+    passed,
+    failed,
+    skipped,
+    duration,
+    passRate: total > 0 ? (passed / total) * 100 : 0,
+  };
+}

--- a/e2e-tests/src/utils/waiters.ts
+++ b/e2e-tests/src/utils/waiters.ts
@@ -1,0 +1,138 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Wait utilities for E2E tests
+ */
+
+/**
+ * Wait for loading spinner to disappear
+ */
+export async function waitForLoadingComplete(
+  page: Page,
+  timeout = 30000
+): Promise<void> {
+  const spinner = page.getByTestId('loading-spinner');
+  await spinner.waitFor({ state: 'hidden', timeout });
+}
+
+/**
+ * Wait for element to contain text
+ */
+export async function waitForText(
+  locator: Locator,
+  text: string,
+  timeout = 10000
+): Promise<void> {
+  await locator.filter({ hasText: text }).waitFor({ state: 'visible', timeout });
+}
+
+/**
+ * Wait for network request to complete
+ */
+export async function waitForApiResponse(
+  page: Page,
+  urlPattern: string | RegExp,
+  timeout = 30000
+): Promise<void> {
+  await page.waitForResponse(
+    (response) => {
+      const url = response.url();
+      if (typeof urlPattern === 'string') {
+        return url.includes(urlPattern);
+      }
+      return urlPattern.test(url);
+    },
+    { timeout }
+  );
+}
+
+/**
+ * Wait for multiple API requests to complete
+ */
+export async function waitForMultipleApiResponses(
+  page: Page,
+  urlPatterns: (string | RegExp)[],
+  timeout = 30000
+): Promise<void> {
+  await Promise.all(
+    urlPatterns.map((pattern) => waitForApiResponse(page, pattern, timeout))
+  );
+}
+
+/**
+ * Wait for page navigation
+ */
+export async function waitForNavigation(
+  page: Page,
+  urlPattern: string | RegExp,
+  timeout = 30000
+): Promise<void> {
+  await page.waitForURL(urlPattern, { timeout });
+}
+
+/**
+ * Wait for animation to complete
+ */
+export async function waitForAnimation(
+  locator: Locator,
+  timeout = 5000
+): Promise<void> {
+  // Wait for element to be stable (no animations)
+  await locator.evaluate((el) => {
+    return new Promise<void>((resolve) => {
+      const checkAnimation = () => {
+        const animations = el.getAnimations();
+        if (animations.length === 0) {
+          resolve();
+        } else {
+          requestAnimationFrame(checkAnimation);
+        }
+      };
+      checkAnimation();
+    });
+  });
+}
+
+/**
+ * Retry action until success
+ */
+export async function retry<T>(
+  action: () => Promise<T>,
+  maxRetries = 3,
+  delay = 1000
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await action();
+    } catch (error) {
+      lastError = error as Error;
+      if (i < maxRetries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Wait for condition to be true
+ */
+export async function waitForCondition(
+  condition: () => Promise<boolean>,
+  timeout = 10000,
+  pollInterval = 100
+): Promise<void> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    if (await condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+  }
+
+  throw new Error(`Condition not met within ${timeout}ms`);
+}

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@fixtures/*": ["./src/fixtures/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@api/*": ["./src/api/*"],
+      "@utils/*": ["./src/utils/*"]
+    }
+  },
+  "include": ["src/**/*", "playwright.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Initialize Playwright E2E testing project in `/e2e-tests/`
- Add TypeScript configuration with strict mode
- Implement Page Object Models for core pages (Login, Packages, PackageDetail, RunDetail)
- Create API testing infrastructure with typed clients
- Add smoke tests for critical user journeys
- Configure for CI with multi-browser support

## Acceptance Criteria Addressed

- [x] Playwright project initialized in `/e2e-tests/`
- [x] TypeScript configuration
- [x] Multiple browser support (Chromium, Firefox, WebKit)
- [x] Base test fixtures and helpers
- [x] CI integration ready (headless mode)
- [x] Screenshot on failure

## Test plan

- [ ] Run `npm install` in e2e-tests directory
- [ ] Run `npx playwright install` to install browsers
- [ ] Run `npm test` to verify tests execute (will fail until frontend/backend are available)
- [ ] Verify TypeScript compilation passes

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)