### PR TITLE
[DevOps] feat: PostgreSQL Kubernetes deployment (#6)

### DIFF
--- a/infrastructure/kubernetes/base/data-services/.gitignore
+++ b/infrastructure/kubernetes/base/data-services/.gitignore
@@ -1,0 +1,6 @@
+# Secrets should not be committed
+**/secrets.yaml
+!**/secrets.yaml.example
+
+# Helm chart downloads
+charts/

--- a/infrastructure/kubernetes/base/data-services/postgresql/README.md
+++ b/infrastructure/kubernetes/base/data-services/postgresql/README.md
@@ -1,0 +1,220 @@
+# PostgreSQL Deployment for QAWave
+
+PostgreSQL 16 database deployment using Bitnami Helm chart.
+
+## Quick Start
+
+### 1. Add Helm Repository
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+```
+
+### 2. Create Namespace
+
+```bash
+kubectl create namespace qawave
+```
+
+### 3. Generate Passwords
+
+```bash
+# Generate secure passwords
+POSTGRES_PASSWORD=$(openssl rand -base64 32)
+QAWAVE_PASSWORD=$(openssl rand -base64 32)
+
+echo "Postgres admin password: $POSTGRES_PASSWORD"
+echo "QAWave app password: $QAWAVE_PASSWORD"
+```
+
+### 4. Install PostgreSQL
+
+```bash
+helm install postgresql bitnami/postgresql \
+  --namespace qawave \
+  --values values.yaml \
+  --set auth.postgresPassword="$POSTGRES_PASSWORD" \
+  --set auth.password="$QAWAVE_PASSWORD"
+```
+
+### 5. Apply Connection Secrets
+
+```bash
+kubectl apply -f secrets.yaml
+kubectl apply -f configmap.yaml
+```
+
+## Verify Installation
+
+```bash
+# Check pod status
+kubectl get pods -n qawave -l app.kubernetes.io/name=postgresql
+
+# Check service
+kubectl get svc -n qawave postgresql
+
+# Test connection
+kubectl run postgresql-client --rm --tty -i --restart='Never' \
+  --namespace qawave \
+  --image docker.io/bitnami/postgresql:16 \
+  --env="PGPASSWORD=$QAWAVE_PASSWORD" \
+  --command -- psql --host postgresql -U qawave -d qawave -p 5432
+```
+
+## Configuration
+
+### values.yaml
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `image.tag` | 16.2.0 | PostgreSQL version |
+| `auth.database` | qawave | Application database |
+| `auth.username` | qawave | Application user |
+| `primary.persistence.size` | 20Gi | Data volume size |
+| `primary.resources.requests.memory` | 512Mi | Memory request |
+| `primary.resources.limits.memory` | 2Gi | Memory limit |
+
+### PostgreSQL Tuning
+
+Configuration optimized for:
+- Up to 200 concurrent connections
+- 2GB memory limit
+- SSD storage (random_page_cost = 1.1)
+
+Key parameters:
+```
+shared_buffers = 512MB
+effective_cache_size = 1536MB
+max_connections = 200
+```
+
+## Connection Strings
+
+### R2DBC (for Spring WebFlux)
+
+```
+r2dbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+```
+
+### JDBC (for migrations)
+
+```
+jdbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+```
+
+## Backup Strategy
+
+### Option 1: pg_dump CronJob
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgresql-backup
+spec:
+  schedule: "0 2 * * *"  # Daily at 2 AM
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: backup
+            image: bitnami/postgresql:16
+            command:
+            - /bin/bash
+            - -c
+            - |
+              PGPASSWORD=$POSTGRES_PASSWORD pg_dump \
+                -h postgresql -U postgres qawave \
+                | gzip > /backup/qawave-$(date +%Y%m%d).sql.gz
+            env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: postgres-password
+            volumeMounts:
+            - name: backup
+              mountPath: /backup
+          volumes:
+          - name: backup
+            persistentVolumeClaim:
+              claimName: postgresql-backup
+          restartPolicy: OnFailure
+```
+
+### Option 2: WAL-G Continuous Backup
+
+For production, consider using WAL-G with S3-compatible storage:
+- Point-in-time recovery
+- Continuous archiving
+- Minimal data loss
+
+## Monitoring
+
+### Prometheus Metrics
+
+PostgreSQL exporter is enabled via `metrics.enabled: true`.
+
+Key metrics:
+- `pg_stat_activity_count` - Active connections
+- `pg_database_size_bytes` - Database size
+- `pg_stat_user_tables_*` - Table statistics
+- `pg_replication_lag` - Replication lag (if replicas)
+
+### Grafana Dashboard
+
+Import dashboard ID: **9628** (PostgreSQL Database)
+
+## Troubleshooting
+
+### Cannot connect to database
+
+```bash
+# Check pod status
+kubectl describe pod -n qawave -l app.kubernetes.io/name=postgresql
+
+# Check logs
+kubectl logs -n qawave -l app.kubernetes.io/name=postgresql
+
+# Verify service
+kubectl get endpoints -n qawave postgresql
+```
+
+### Out of connections
+
+```bash
+# Check current connections
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -c \
+  "SELECT count(*) FROM pg_stat_activity;"
+
+# Kill idle connections
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE state = 'idle' AND query_start < now() - interval '1 hour';"
+```
+
+### Slow queries
+
+```bash
+# Find slow queries
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -c \
+  "SELECT pid, now() - query_start as duration, query FROM pg_stat_activity WHERE state = 'active' ORDER BY duration DESC;"
+```
+
+## Upgrade
+
+```bash
+# Backup first!
+helm upgrade postgresql bitnami/postgresql \
+  --namespace qawave \
+  --values values.yaml \
+  --set auth.postgresPassword="$POSTGRES_PASSWORD" \
+  --set auth.password="$QAWAVE_PASSWORD"
+```
+
+## Related Documentation
+
+- [Bitnami PostgreSQL Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/16/)
+- [R2DBC PostgreSQL](https://github.com/pgjdbc/r2dbc-postgresql)

--- a/infrastructure/kubernetes/base/data-services/postgresql/configmap.yaml
+++ b/infrastructure/kubernetes/base/data-services/postgresql/configmap.yaml
@@ -1,0 +1,23 @@
+# PostgreSQL ConfigMap
+# Non-sensitive configuration for PostgreSQL
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-config
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+data:
+  # Connection pool settings for application reference
+  POOL_MIN_SIZE: "5"
+  POOL_MAX_SIZE: "20"
+  POOL_INITIAL_SIZE: "10"
+
+  # Timeout settings (milliseconds)
+  CONNECTION_TIMEOUT: "30000"
+  STATEMENT_TIMEOUT: "60000"
+
+  # Health check query
+  VALIDATION_QUERY: "SELECT 1"

--- a/infrastructure/kubernetes/base/data-services/postgresql/kustomization.yaml
+++ b/infrastructure/kubernetes/base/data-services/postgresql/kustomization.yaml
@@ -1,0 +1,18 @@
+# PostgreSQL Kustomization
+# Manages PostgreSQL deployment via Helm inflator
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qawave
+
+# PostgreSQL is deployed via Helm
+# This kustomization manages supplementary resources
+
+resources:
+  - secrets.yaml
+  - configmap.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: qawave
+  app.kubernetes.io/component: database

--- a/infrastructure/kubernetes/base/data-services/postgresql/secrets.yaml
+++ b/infrastructure/kubernetes/base/data-services/postgresql/secrets.yaml
@@ -1,0 +1,28 @@
+# PostgreSQL Secrets
+# NOTE: This contains placeholder values only!
+# For production, use:
+# - Sealed Secrets
+# - External Secrets Operator
+# - Vault integration
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-connection
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+type: Opaque
+stringData:
+  # R2DBC connection URL for Spring WebFlux
+  R2DBC_URL: r2dbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+
+  # Standard JDBC URL (for migrations, etc.)
+  JDBC_URL: jdbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+
+  # Individual components
+  DB_HOST: postgresql.qawave.svc.cluster.local
+  DB_PORT: "5432"
+  DB_NAME: qawave
+  DB_USER: qawave

--- a/infrastructure/kubernetes/base/data-services/postgresql/secrets.yaml.example
+++ b/infrastructure/kubernetes/base/data-services/postgresql/secrets.yaml.example
@@ -1,0 +1,53 @@
+# PostgreSQL Secrets Template
+# Copy to secrets.yaml and fill in base64 encoded values
+# NEVER commit secrets.yaml to git!
+#
+# Generate passwords:
+#   openssl rand -base64 32 | tr -d '\n' | base64
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-secrets
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+type: Opaque
+data:
+  # PostgreSQL admin (postgres) password
+  # echo -n 'your-admin-password' | base64
+  postgres-password: CHANGEME
+
+  # QAWave application user password
+  # echo -n 'your-app-password' | base64
+  password: CHANGEME
+
+  # Replication password (if using replicas)
+  # echo -n 'your-replication-password' | base64
+  replication-password: CHANGEME
+---
+# Connection string secret for application use
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-connection
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: database
+type: Opaque
+stringData:
+  # R2DBC connection URL for Spring WebFlux
+  # Format: r2dbc:postgresql://host:port/database
+  R2DBC_URL: r2dbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+
+  # Standard JDBC URL (for migrations, etc.)
+  JDBC_URL: jdbc:postgresql://postgresql.qawave.svc.cluster.local:5432/qawave
+
+  # Individual components
+  DB_HOST: postgresql.qawave.svc.cluster.local
+  DB_PORT: "5432"
+  DB_NAME: qawave
+  DB_USER: qawave
+  # Password reference - application should read from postgresql-secrets

--- a/infrastructure/kubernetes/base/data-services/postgresql/values.yaml
+++ b/infrastructure/kubernetes/base/data-services/postgresql/values.yaml
@@ -1,0 +1,130 @@
+# PostgreSQL Helm Values for QAWave
+# Chart: bitnami/postgresql
+# Version: 15.x
+#
+# Install:
+#   helm repo add bitnami https://charts.bitnami.com/bitnami
+#   helm install postgresql bitnami/postgresql -n qawave -f values.yaml
+#
+
+# PostgreSQL version
+image:
+  tag: "16.2.0"
+
+# Authentication
+auth:
+  database: qawave
+  username: qawave
+  # Password should be overridden via --set or secrets
+  # existingSecret: postgresql-secrets
+  # secretKeys:
+  #   adminPasswordKey: postgres-password
+  #   userPasswordKey: password
+
+# Primary instance configuration
+primary:
+  # Resource limits
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+  # Persistence
+  persistence:
+    enabled: true
+    size: 20Gi
+    storageClass: ""  # Use default storage class
+
+  # PostgreSQL configuration
+  configuration: |
+    # Connection settings
+    max_connections = 200
+    shared_buffers = 512MB
+    effective_cache_size = 1536MB
+    maintenance_work_mem = 128MB
+    checkpoint_completion_target = 0.9
+    wal_buffers = 16MB
+    default_statistics_target = 100
+    random_page_cost = 1.1
+    effective_io_concurrency = 200
+    work_mem = 2621kB
+    min_wal_size = 1GB
+    max_wal_size = 4GB
+    max_worker_processes = 4
+    max_parallel_workers_per_gather = 2
+    max_parallel_workers = 4
+    max_parallel_maintenance_workers = 2
+
+    # Logging
+    log_destination = 'stderr'
+    logging_collector = off
+    log_statement = 'ddl'
+    log_min_duration_statement = 1000
+
+  # Init scripts for database setup
+  initdb:
+    scripts:
+      init.sql: |
+        -- Enable required extensions
+        CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+        -- Grant permissions
+        GRANT ALL PRIVILEGES ON DATABASE qawave TO qawave;
+
+  # Pod annotations for monitoring
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+
+  # Affinity rules - prefer scheduling on different nodes
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: postgresql
+            topologyKey: kubernetes.io/hostname
+
+# Metrics exporter for Prometheus
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: false  # Enable if using Prometheus Operator
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+
+# Network policy
+networkPolicy:
+  enabled: true
+  allowExternal: false
+  ingressRules:
+    primaryAccessOnlyFrom:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: qawave
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: backend
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    postgresql: 5432
+
+# Backup configuration (optional - requires external backup solution)
+# For production, consider:
+# - WAL-G for continuous backups
+# - pg_dump cronjob for logical backups
+# - CloudNativePG operator for advanced scenarios


### PR DESCRIPTION
## Summary
- Add PostgreSQL deployment configuration for Kubernetes using Bitnami Helm chart
- Provides persistent database storage for QAWave backend

## Changes

### values.yaml
Helm values for Bitnami PostgreSQL chart:
- PostgreSQL 16.2.0
- Tuned for 2GB memory limit
- 200 max connections
- Prometheus metrics exporter enabled
- Network policy restricts access to backend pods only
- Init scripts enable uuid-ossp and pgcrypto extensions

### Connection Configuration
- `secrets.yaml` - Connection strings for application (R2DBC and JDBC URLs)
- `secrets.yaml.example` - Template for actual password secrets
- `configmap.yaml` - Non-sensitive pool configuration

### README.md
Comprehensive documentation:
- Quick start installation guide
- Connection string formats
- Backup strategy (pg_dump CronJob and WAL-G options)
- Monitoring setup with Prometheus
- Troubleshooting guide

## Acceptance Criteria
- [x] PostgreSQL deployed via Helm (Bitnami chart)
- [x] Persistent volume configured for data (20Gi)
- [x] Connection string available as K8s secret
- [x] Database accessible from backend pods (network policy)
- [x] Backup strategy documented

## Test plan
- [ ] Add Helm repo: `helm repo add bitnami https://charts.bitnami.com/bitnami`
- [ ] Install: `helm install postgresql bitnami/postgresql -n qawave -f values.yaml`
- [ ] Verify pod running
- [ ] Test database connection

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)