### PR TITLE
[Backend] feat: Configure R2DBC for PostgreSQL (#13)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,9 @@ dependencies {
     // H2 for testing
     testRuntimeOnly("io.r2dbc:r2dbc-h2")
     testRuntimeOnly("com.h2database:h2")
+
+    // Kotlin test
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
 kotlin {

--- a/src/main/kotlin/com/qawave/infrastructure/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/config/R2dbcConfig.kt
@@ -1,0 +1,34 @@
+package com.qawave.infrastructure.config
+
+import io.r2dbc.spi.ConnectionFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
+import org.springframework.transaction.ReactiveTransactionManager
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+/**
+ * R2DBC configuration for reactive PostgreSQL access.
+ *
+ * This configuration:
+ * - Enables R2DBC repositories with coroutine support
+ * - Enables R2DBC auditing for createdAt/updatedAt fields
+ * - Configures reactive transaction management
+ */
+@Configuration
+@EnableR2dbcRepositories(basePackages = ["com.qawave.infrastructure.persistence.repository"])
+@EnableR2dbcAuditing
+@EnableTransactionManagement
+class R2dbcConfig {
+
+    /**
+     * Configures the reactive transaction manager for R2DBC.
+     * This enables @Transactional support for suspend functions.
+     */
+    @Bean
+    fun transactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager {
+        return R2dbcTransactionManager(connectionFactory)
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,38 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    pool:
+      initial-size: 10
+      max-size: 50
+      max-idle-time: 10m
+      validation-query: SELECT 1
+
+  flyway:
+    enabled: true
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+    user: ${DB_USER}
+    password: ${DB_PASSWORD}
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+
+logging:
+  level:
+    root: INFO
+    com.qawave: INFO
+    org.springframework.r2dbc: WARN
+
+management:
+  endpoint:
+    health:
+      show-details: when_authorized

--- a/src/test/kotlin/com/qawave/integration/R2dbcPostgresIntegrationTest.kt
+++ b/src/test/kotlin/com/qawave/integration/R2dbcPostgresIntegrationTest.kt
@@ -1,0 +1,124 @@
+package com.qawave.integration
+
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test verifying R2DBC PostgreSQL connectivity using Testcontainers.
+ * This test ensures that:
+ * - R2DBC driver connects to PostgreSQL successfully
+ * - Basic queries execute correctly
+ * - Connection pooling works as expected
+ */
+@SpringBootTest
+@Testcontainers
+@EnableAutoConfiguration(exclude = [
+    RedisAutoConfiguration::class,
+    RedisReactiveAutoConfiguration::class,
+    KafkaAutoConfiguration::class
+])
+class R2dbcPostgresIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply {
+            withDatabaseName("qawave_test")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.r2dbc.url") {
+                "r2dbc:postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
+            }
+            registry.add("spring.r2dbc.username") { postgres.username }
+            registry.add("spring.r2dbc.password") { postgres.password }
+            registry.add("spring.flyway.enabled") { "false" }
+        }
+    }
+
+    @Autowired
+    private lateinit var databaseClient: DatabaseClient
+
+    @Test
+    fun `PostgreSQL container is running`() {
+        assertTrue(postgres.isRunning, "PostgreSQL container should be running")
+    }
+
+    @Test
+    fun `can execute simple query`() = runBlocking {
+        val result = databaseClient.sql("SELECT 1::integer as value")
+            .map { row, _ -> row.get("value", Integer::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertEquals(1, result?.toInt())
+    }
+
+    @Test
+    fun `can get database version`() = runBlocking {
+        val version = databaseClient.sql("SELECT version()")
+            .map { row, _ -> row.get(0, String::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertNotNull(version)
+        assertTrue(version!!.contains("PostgreSQL"), "Should return PostgreSQL version")
+    }
+
+    @Test
+    fun `can create and query temporary table`() = runBlocking {
+        // Create a temporary table
+        databaseClient.sql("""
+            CREATE TEMPORARY TABLE test_table (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(100) NOT NULL
+            )
+        """).fetch().rowsUpdated().awaitFirst()
+
+        // Insert a row
+        databaseClient.sql("INSERT INTO test_table (name) VALUES ('test_value')")
+            .fetch()
+            .rowsUpdated()
+            .awaitFirst()
+
+        // Query the row
+        val name = databaseClient.sql("SELECT name FROM test_table WHERE id = 1")
+            .map { row, _ -> row.get("name", String::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertEquals("test_value", name)
+    }
+
+    @Test
+    fun `connection pool is configured`() = runBlocking {
+        // Execute multiple queries to verify pooling works
+        repeat(10) { index ->
+            val result = databaseClient.sql("SELECT $index::integer as value")
+                .map { row, _ -> row.get("value", Integer::class.java) }
+                .first()
+                .awaitFirst()
+            assertEquals(index, result?.toInt())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added R2dbcConfig for reactive database configuration
- Enabled R2DBC repositories with coroutine support
- Added production profile configuration
- Verified connectivity with Testcontainers PostgreSQL integration tests

## Acceptance Criteria
- [x] R2DBC PostgreSQL driver configured
- [x] Spring Data R2DBC enabled
- [x] Connection pooling configured (r2dbc-pool)
- [x] Test with Testcontainers PostgreSQL
- [x] Environment-based configuration (dev/prod)

## Test Plan
- [x] PostgreSQL container starts and is accessible
- [x] Simple queries execute correctly
- [x] Database version retrieval works
- [x] Temporary table creation and querying works
- [x] Connection pooling handles multiple queries

## Dependencies
This PR depends on PR #41 (Spring Boot initialization).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)