### PR TITLE
[Backend] feat: Implement R2DBC repositories with coroutines (#14)

### DIFF
--- a/src/main/kotlin/com/qawave/infrastructure/config/R2dbcConfig.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/config/R2dbcConfig.kt
@@ -1,0 +1,34 @@
+package com.qawave.infrastructure.config
+
+import io.r2dbc.spi.ConnectionFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories
+import org.springframework.r2dbc.connection.R2dbcTransactionManager
+import org.springframework.transaction.ReactiveTransactionManager
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+/**
+ * R2DBC configuration for reactive PostgreSQL access.
+ *
+ * This configuration:
+ * - Enables R2DBC repositories with coroutine support
+ * - Enables R2DBC auditing for createdAt/updatedAt fields
+ * - Configures reactive transaction management
+ */
+@Configuration
+@EnableR2dbcRepositories(basePackages = ["com.qawave.infrastructure.persistence.repository"])
+@EnableR2dbcAuditing
+@EnableTransactionManagement
+class R2dbcConfig {
+
+    /**
+     * Configures the reactive transaction manager for R2DBC.
+     * This enables @Transactional support for suspend functions.
+     */
+    @Bean
+    fun transactionManager(connectionFactory: ConnectionFactory): ReactiveTransactionManager {
+        return R2dbcTransactionManager(connectionFactory)
+    }
+}

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/entity/QaPackageEntity.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/entity/QaPackageEntity.kt
@@ -1,0 +1,69 @@
+package com.qawave.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC entity for QA Package.
+ * Maps to the qa_packages table in PostgreSQL.
+ */
+@Table("qa_packages")
+data class QaPackageEntity(
+    @Id
+    val id: UUID? = null,
+
+    @Column("name")
+    val name: String,
+
+    @Column("description")
+    val description: String? = null,
+
+    @Column("spec_url")
+    val specUrl: String? = null,
+
+    @Column("spec_content")
+    val specContent: String? = null,
+
+    @Column("spec_hash")
+    val specHash: String? = null,
+
+    @Column("base_url")
+    val baseUrl: String,
+
+    @Column("requirements")
+    val requirements: String? = null,
+
+    @Column("status")
+    val status: String,
+
+    @Column("config_json")
+    val configJson: String? = null,
+
+    @Column("coverage_json")
+    val coverageJson: String? = null,
+
+    @Column("qa_summary_json")
+    val qaSummaryJson: String? = null,
+
+    @Column("triggered_by")
+    val triggeredBy: String,
+
+    @Column("started_at")
+    val startedAt: Instant? = null,
+
+    @Column("completed_at")
+    val completedAt: Instant? = null,
+
+    @CreatedDate
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+
+    @LastModifiedDate
+    @Column("updated_at")
+    val updatedAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestRunEntity.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestRunEntity.kt
@@ -1,0 +1,51 @@
+package com.qawave.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC entity for Test Run.
+ * Maps to the test_runs table in PostgreSQL.
+ */
+@Table("test_runs")
+data class TestRunEntity(
+    @Id
+    val id: UUID? = null,
+
+    @Column("scenario_id")
+    val scenarioId: UUID,
+
+    @Column("qa_package_id")
+    val qaPackageId: UUID? = null,
+
+    @Column("triggered_by")
+    val triggeredBy: String,
+
+    @Column("base_url")
+    val baseUrl: String,
+
+    @Column("status")
+    val status: String,
+
+    @Column("environment_json")
+    val environmentJson: String? = null,
+
+    @Column("started_at")
+    val startedAt: Instant,
+
+    @Column("completed_at")
+    val completedAt: Instant? = null,
+
+    @CreatedDate
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+
+    @LastModifiedDate
+    @Column("updated_at")
+    val updatedAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestScenarioEntity.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestScenarioEntity.kt
@@ -1,0 +1,51 @@
+package com.qawave.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC entity for Test Scenario.
+ * Maps to the test_scenarios table in PostgreSQL.
+ */
+@Table("test_scenarios")
+data class TestScenarioEntity(
+    @Id
+    val id: UUID? = null,
+
+    @Column("suite_id")
+    val suiteId: UUID? = null,
+
+    @Column("qa_package_id")
+    val qaPackageId: UUID? = null,
+
+    @Column("name")
+    val name: String,
+
+    @Column("description")
+    val description: String? = null,
+
+    @Column("steps_json")
+    val stepsJson: String,
+
+    @Column("tags")
+    val tags: String? = null, // Stored as JSON array
+
+    @Column("source")
+    val source: String,
+
+    @Column("status")
+    val status: String,
+
+    @CreatedDate
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+
+    @LastModifiedDate
+    @Column("updated_at")
+    val updatedAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestStepResultEntity.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/entity/TestStepResultEntity.kt
@@ -1,0 +1,53 @@
+package com.qawave.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC entity for Test Step Result.
+ * Maps to the test_step_results table in PostgreSQL.
+ */
+@Table("test_step_results")
+data class TestStepResultEntity(
+    @Id
+    val id: UUID? = null,
+
+    @Column("run_id")
+    val runId: UUID,
+
+    @Column("step_index")
+    val stepIndex: Int,
+
+    @Column("step_name")
+    val stepName: String,
+
+    @Column("actual_status")
+    val actualStatus: Int? = null,
+
+    @Column("actual_headers_json")
+    val actualHeadersJson: String? = null,
+
+    @Column("actual_body")
+    val actualBody: String? = null,
+
+    @Column("passed")
+    val passed: Boolean,
+
+    @Column("assertions_json")
+    val assertionsJson: String? = null,
+
+    @Column("extracted_values_json")
+    val extractedValuesJson: String? = null,
+
+    @Column("error_message")
+    val errorMessage: String? = null,
+
+    @Column("duration_ms")
+    val durationMs: Long,
+
+    @Column("executed_at")
+    val executedAt: Instant
+)

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/repository/QaPackageR2dbcRepository.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/repository/QaPackageR2dbcRepository.kt
@@ -1,0 +1,58 @@
+package com.qawave.infrastructure.persistence.repository
+
+import com.qawave.infrastructure.persistence.entity.QaPackageEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC repository for QA Packages.
+ * Uses Kotlin coroutines for non-blocking database access.
+ */
+@Repository
+interface QaPackageR2dbcRepository : CoroutineCrudRepository<QaPackageEntity, UUID> {
+
+    /**
+     * Find all packages with a specific status.
+     */
+    suspend fun findByStatus(status: String): List<QaPackageEntity>
+
+    /**
+     * Stream packages with a specific status.
+     */
+    fun findAllByStatus(status: String): Flow<QaPackageEntity>
+
+    /**
+     * Find packages triggered by a specific user.
+     */
+    suspend fun findByTriggeredBy(triggeredBy: String): List<QaPackageEntity>
+
+    /**
+     * Find packages created after a specific time.
+     */
+    @Query("SELECT * FROM qa_packages WHERE created_at > :since ORDER BY created_at DESC")
+    fun findRecentPackages(since: Instant): Flow<QaPackageEntity>
+
+    /**
+     * Find packages by spec hash for deduplication.
+     */
+    suspend fun findBySpecHash(specHash: String): QaPackageEntity?
+
+    /**
+     * Find incomplete packages (not in terminal status).
+     */
+    @Query("""
+        SELECT * FROM qa_packages
+        WHERE status NOT IN ('COMPLETE', 'FAILED_SPEC_FETCH', 'FAILED_GENERATION', 'FAILED_EXECUTION', 'CANCELLED')
+        ORDER BY created_at DESC
+    """)
+    fun findIncompletePackages(): Flow<QaPackageEntity>
+
+    /**
+     * Count packages by status.
+     */
+    suspend fun countByStatus(status: String): Long
+}

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestRunR2dbcRepository.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestRunR2dbcRepository.kt
@@ -1,0 +1,101 @@
+package com.qawave.infrastructure.persistence.repository
+
+import com.qawave.infrastructure.persistence.entity.TestRunEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC repository for Test Runs.
+ * Uses Kotlin coroutines for non-blocking database access.
+ */
+@Repository
+interface TestRunR2dbcRepository : CoroutineCrudRepository<TestRunEntity, UUID> {
+
+    /**
+     * Find runs for a specific scenario.
+     */
+    suspend fun findByScenarioId(scenarioId: UUID): List<TestRunEntity>
+
+    /**
+     * Stream runs for a specific scenario.
+     */
+    fun findAllByScenarioId(scenarioId: UUID): Flow<TestRunEntity>
+
+    /**
+     * Find runs belonging to a QA package.
+     */
+    suspend fun findByQaPackageId(qaPackageId: UUID): List<TestRunEntity>
+
+    /**
+     * Stream runs belonging to a QA package.
+     */
+    fun findAllByQaPackageId(qaPackageId: UUID): Flow<TestRunEntity>
+
+    /**
+     * Find runs by status.
+     */
+    suspend fun findByStatus(status: String): List<TestRunEntity>
+
+    /**
+     * Stream runs by status.
+     */
+    fun findAllByStatus(status: String): Flow<TestRunEntity>
+
+    /**
+     * Find the latest run for a scenario.
+     */
+    @Query("SELECT * FROM test_runs WHERE scenario_id = :scenarioId ORDER BY created_at DESC LIMIT 1")
+    suspend fun findLatestByScenarioId(scenarioId: UUID): TestRunEntity?
+
+    /**
+     * Find runs created after a specific time.
+     */
+    @Query("SELECT * FROM test_runs WHERE created_at > :since ORDER BY created_at DESC")
+    fun findRecentRuns(since: Instant): Flow<TestRunEntity>
+
+    /**
+     * Find incomplete runs (not in terminal status).
+     */
+    @Query("""
+        SELECT * FROM test_runs
+        WHERE status NOT IN ('PASSED', 'FAILED', 'ERROR', 'CANCELLED')
+        ORDER BY created_at DESC
+    """)
+    fun findIncompleteRuns(): Flow<TestRunEntity>
+
+    /**
+     * Count runs by status.
+     */
+    suspend fun countByStatus(status: String): Long
+
+    /**
+     * Count runs for a QA package.
+     */
+    suspend fun countByQaPackageId(qaPackageId: UUID): Long
+
+    /**
+     * Count passed runs for a QA package.
+     */
+    @Query("SELECT COUNT(*) FROM test_runs WHERE qa_package_id = :qaPackageId AND status = 'PASSED'")
+    suspend fun countPassedByQaPackageId(qaPackageId: UUID): Long
+
+    /**
+     * Count failed runs for a QA package.
+     */
+    @Query("SELECT COUNT(*) FROM test_runs WHERE qa_package_id = :qaPackageId AND status = 'FAILED'")
+    suspend fun countFailedByQaPackageId(qaPackageId: UUID): Long
+
+    /**
+     * Delete all runs for a scenario.
+     */
+    suspend fun deleteByScenarioId(scenarioId: UUID)
+
+    /**
+     * Delete all runs for a QA package.
+     */
+    suspend fun deleteByQaPackageId(qaPackageId: UUID)
+}

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestScenarioR2dbcRepository.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestScenarioR2dbcRepository.kt
@@ -1,0 +1,74 @@
+package com.qawave.infrastructure.persistence.repository
+
+import com.qawave.infrastructure.persistence.entity.TestScenarioEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC repository for Test Scenarios.
+ * Uses Kotlin coroutines for non-blocking database access.
+ */
+@Repository
+interface TestScenarioR2dbcRepository : CoroutineCrudRepository<TestScenarioEntity, UUID> {
+
+    /**
+     * Find scenarios belonging to a QA package.
+     */
+    suspend fun findByQaPackageId(qaPackageId: UUID): List<TestScenarioEntity>
+
+    /**
+     * Stream scenarios belonging to a QA package.
+     */
+    fun findAllByQaPackageId(qaPackageId: UUID): Flow<TestScenarioEntity>
+
+    /**
+     * Find scenarios belonging to a test suite.
+     */
+    suspend fun findBySuiteId(suiteId: UUID): List<TestScenarioEntity>
+
+    /**
+     * Find scenarios by status.
+     */
+    suspend fun findByStatus(status: String): List<TestScenarioEntity>
+
+    /**
+     * Stream scenarios by status.
+     */
+    fun findAllByStatus(status: String): Flow<TestScenarioEntity>
+
+    /**
+     * Find scenarios created after a specific time.
+     */
+    @Query("SELECT * FROM test_scenarios WHERE created_at > :since ORDER BY created_at DESC")
+    fun findRecentScenarios(since: Instant): Flow<TestScenarioEntity>
+
+    /**
+     * Find scenarios by source type.
+     */
+    suspend fun findBySource(source: String): List<TestScenarioEntity>
+
+    /**
+     * Count scenarios by QA package.
+     */
+    suspend fun countByQaPackageId(qaPackageId: UUID): Long
+
+    /**
+     * Count scenarios by status.
+     */
+    suspend fun countByStatus(status: String): Long
+
+    /**
+     * Find scenarios with specific tags (JSON contains).
+     */
+    @Query("SELECT * FROM test_scenarios WHERE tags::jsonb @> :tag::jsonb")
+    fun findByTag(tag: String): Flow<TestScenarioEntity>
+
+    /**
+     * Delete all scenarios for a QA package.
+     */
+    suspend fun deleteByQaPackageId(qaPackageId: UUID)
+}

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestStepResultR2dbcRepository.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/repository/TestStepResultR2dbcRepository.kt
@@ -1,0 +1,82 @@
+package com.qawave.infrastructure.persistence.repository
+
+import com.qawave.infrastructure.persistence.entity.TestStepResultEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * R2DBC repository for Test Step Results.
+ * Uses Kotlin coroutines for non-blocking database access.
+ */
+@Repository
+interface TestStepResultR2dbcRepository : CoroutineCrudRepository<TestStepResultEntity, UUID> {
+
+    /**
+     * Find all step results for a test run.
+     */
+    suspend fun findByRunId(runId: UUID): List<TestStepResultEntity>
+
+    /**
+     * Stream all step results for a test run.
+     */
+    fun findAllByRunId(runId: UUID): Flow<TestStepResultEntity>
+
+    /**
+     * Find step results ordered by step index.
+     */
+    @Query("SELECT * FROM test_step_results WHERE run_id = :runId ORDER BY step_index ASC")
+    suspend fun findByRunIdOrderByStepIndex(runId: UUID): List<TestStepResultEntity>
+
+    /**
+     * Find a specific step result by run ID and step index.
+     */
+    suspend fun findByRunIdAndStepIndex(runId: UUID, stepIndex: Int): TestStepResultEntity?
+
+    /**
+     * Find passed step results for a run.
+     */
+    suspend fun findByRunIdAndPassed(runId: UUID, passed: Boolean): List<TestStepResultEntity>
+
+    /**
+     * Count step results by run ID.
+     */
+    suspend fun countByRunId(runId: UUID): Long
+
+    /**
+     * Count passed step results for a run.
+     */
+    @Query("SELECT COUNT(*) FROM test_step_results WHERE run_id = :runId AND passed = true")
+    suspend fun countPassedByRunId(runId: UUID): Long
+
+    /**
+     * Count failed step results for a run.
+     */
+    @Query("SELECT COUNT(*) FROM test_step_results WHERE run_id = :runId AND passed = false")
+    suspend fun countFailedByRunId(runId: UUID): Long
+
+    /**
+     * Find step results with errors.
+     */
+    @Query("SELECT * FROM test_step_results WHERE run_id = :runId AND error_message IS NOT NULL")
+    suspend fun findWithErrorsByRunId(runId: UUID): List<TestStepResultEntity>
+
+    /**
+     * Delete all step results for a test run.
+     */
+    suspend fun deleteByRunId(runId: UUID)
+
+    /**
+     * Get average duration for passed steps in a run.
+     */
+    @Query("SELECT AVG(duration_ms) FROM test_step_results WHERE run_id = :runId AND passed = true")
+    suspend fun getAverageDurationForPassedSteps(runId: UUID): Double?
+
+    /**
+     * Get max duration step in a run.
+     */
+    @Query("SELECT * FROM test_step_results WHERE run_id = :runId ORDER BY duration_ms DESC LIMIT 1")
+    suspend fun findSlowestStepByRunId(runId: UUID): TestStepResultEntity?
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,38 @@
+spring:
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    pool:
+      initial-size: 10
+      max-size: 50
+      max-idle-time: 10m
+      validation-query: SELECT 1
+
+  flyway:
+    enabled: true
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME}
+    user: ${DB_USER}
+    password: ${DB_PASSWORD}
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+
+logging:
+  level:
+    root: INFO
+    com.qawave: INFO
+    org.springframework.r2dbc: WARN
+
+management:
+  endpoint:
+    health:
+      show-details: when_authorized

--- a/src/test/kotlin/com/qawave/integration/R2dbcPostgresIntegrationTest.kt
+++ b/src/test/kotlin/com/qawave/integration/R2dbcPostgresIntegrationTest.kt
@@ -1,0 +1,124 @@
+package com.qawave.integration
+
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.r2dbc.core.DatabaseClient
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration test verifying R2DBC PostgreSQL connectivity using Testcontainers.
+ * This test ensures that:
+ * - R2DBC driver connects to PostgreSQL successfully
+ * - Basic queries execute correctly
+ * - Connection pooling works as expected
+ */
+@SpringBootTest
+@Testcontainers
+@EnableAutoConfiguration(exclude = [
+    RedisAutoConfiguration::class,
+    RedisReactiveAutoConfiguration::class,
+    KafkaAutoConfiguration::class
+])
+class R2dbcPostgresIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres = PostgreSQLContainer("postgres:16-alpine").apply {
+            withDatabaseName("qawave_test")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.r2dbc.url") {
+                "r2dbc:postgresql://${postgres.host}:${postgres.firstMappedPort}/${postgres.databaseName}"
+            }
+            registry.add("spring.r2dbc.username") { postgres.username }
+            registry.add("spring.r2dbc.password") { postgres.password }
+            registry.add("spring.flyway.enabled") { "false" }
+        }
+    }
+
+    @Autowired
+    private lateinit var databaseClient: DatabaseClient
+
+    @Test
+    fun `PostgreSQL container is running`() {
+        assertTrue(postgres.isRunning, "PostgreSQL container should be running")
+    }
+
+    @Test
+    fun `can execute simple query`() = runBlocking {
+        val result = databaseClient.sql("SELECT 1::integer as value")
+            .map { row, _ -> row.get("value", Integer::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertEquals(1, result?.toInt())
+    }
+
+    @Test
+    fun `can get database version`() = runBlocking {
+        val version = databaseClient.sql("SELECT version()")
+            .map { row, _ -> row.get(0, String::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertNotNull(version)
+        assertTrue(version!!.contains("PostgreSQL"), "Should return PostgreSQL version")
+    }
+
+    @Test
+    fun `can create and query temporary table`() = runBlocking {
+        // Create a temporary table
+        databaseClient.sql("""
+            CREATE TEMPORARY TABLE test_table (
+                id SERIAL PRIMARY KEY,
+                name VARCHAR(100) NOT NULL
+            )
+        """).fetch().rowsUpdated().awaitFirst()
+
+        // Insert a row
+        databaseClient.sql("INSERT INTO test_table (name) VALUES ('test_value')")
+            .fetch()
+            .rowsUpdated()
+            .awaitFirst()
+
+        // Query the row
+        val name = databaseClient.sql("SELECT name FROM test_table WHERE id = 1")
+            .map { row, _ -> row.get("name", String::class.java) }
+            .first()
+            .awaitFirst()
+
+        assertEquals("test_value", name)
+    }
+
+    @Test
+    fun `connection pool is configured`() = runBlocking {
+        // Execute multiple queries to verify pooling works
+        repeat(10) { index ->
+            val result = databaseClient.sql("SELECT $index::integer as value")
+                .map { row, _ -> row.get("value", Integer::class.java) }
+                .first()
+                .awaitFirst()
+            assertEquals(index, result?.toInt())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Created R2DBC entity classes for all domain models
- Implemented Spring Data R2DBC repositories with CoroutineCrudRepository
- Added custom queries using @Query annotations
- Included Flow-based streaming methods for large result sets
- Added R2DBC configuration and Testcontainers integration tests

## Entities
- **QaPackageEntity**: Maps QA Package domain model to qa_packages table
- **TestScenarioEntity**: Maps Test Scenario to test_scenarios table
- **TestRunEntity**: Maps Test Run to test_runs table
- **TestStepResultEntity**: Maps Test Step Result to test_step_results table

## Repositories
- **QaPackageR2dbcRepository**: Full CRUD + status queries, deduplication by spec hash
- **TestScenarioR2dbcRepository**: Queries by package, suite, status, source, tags
- **TestRunR2dbcRepository**: Queries by scenario, package, status, metrics
- **TestStepResultR2dbcRepository**: Queries by run, step index, pass/fail stats

## Acceptance Criteria
- [x] QaPackageRepository with suspend functions
- [x] TestScenarioRepository with suspend functions
- [x] TestRunRepository with suspend functions
- [x] TestStepResultRepository with suspend functions
- [x] Custom queries using @Query where needed
- [x] Pagination support (via Flow streaming)

## Dependencies
This PR depends on:
- PR #48 (Domain models)
- Includes R2DBC config from PR #51

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)