### PR TITLE
[Backend] feat: Implement AI client (OpenAI/Venice) with WebClient (#16)

### DIFF
--- a/src/main/kotlin/com/qawave/application/port/AiClient.kt
+++ b/src/main/kotlin/com/qawave/application/port/AiClient.kt
@@ -1,0 +1,116 @@
+package com.qawave.application.port
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Port interface for AI provider interactions.
+ * Abstracts the underlying AI provider (OpenAI, Venice, etc.)
+ * to enable easy switching and testing.
+ */
+interface AiClient {
+
+    /**
+     * Sends a completion request to the AI provider.
+     *
+     * @param request The completion request with system and user prompts
+     * @return The AI's response
+     */
+    suspend fun complete(request: AiCompletionRequest): AiResponse
+
+    /**
+     * Sends a streaming completion request to the AI provider.
+     * Returns a Flow for real-time token streaming.
+     *
+     * @param request The completion request with system and user prompts
+     * @return A Flow of response chunks
+     */
+    fun streamComplete(request: AiCompletionRequest): Flow<AiResponseChunk>
+
+    /**
+     * Checks if the AI provider is available and responding.
+     */
+    suspend fun healthCheck(): Boolean
+
+    /**
+     * Returns the name of the AI provider.
+     */
+    val providerName: String
+}
+
+/**
+ * Request for AI completion.
+ */
+data class AiCompletionRequest(
+    val systemPrompt: String,
+    val userPrompt: String,
+    val temperature: Double = 0.2,
+    val maxTokens: Int = 4096,
+    val model: String? = null,
+    val responseFormat: ResponseFormat = ResponseFormat.TEXT,
+    val metadata: Map<String, String> = emptyMap()
+)
+
+/**
+ * Response format options.
+ */
+enum class ResponseFormat {
+    TEXT,
+    JSON
+}
+
+/**
+ * Response from AI completion.
+ */
+data class AiResponse(
+    val content: String,
+    val model: String,
+    val usage: TokenUsage?,
+    val finishReason: String?,
+    val metadata: Map<String, Any> = emptyMap()
+)
+
+/**
+ * Token usage statistics.
+ */
+data class TokenUsage(
+    val promptTokens: Int,
+    val completionTokens: Int,
+    val totalTokens: Int
+)
+
+/**
+ * A chunk from streaming response.
+ */
+data class AiResponseChunk(
+    val content: String,
+    val isComplete: Boolean,
+    val finishReason: String? = null
+)
+
+/**
+ * Exception thrown when AI request fails.
+ */
+open class AiClientException(
+    message: String,
+    open val statusCode: Int? = null,
+    open val provider: String? = null,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)
+
+/**
+ * Exception thrown when AI rate limit is exceeded.
+ */
+class AiRateLimitException(
+    message: String,
+    val retryAfterMs: Long? = null,
+    provider: String? = null
+) : AiClientException(message, statusCode = 429, provider = provider)
+
+/**
+ * Exception thrown when AI request times out.
+ */
+class AiTimeoutException(
+    message: String,
+    val timeoutMs: Long,
+    provider: String? = null
+) : AiClientException(message, provider = provider)

--- a/src/main/kotlin/com/qawave/infrastructure/ai/AiClientConfig.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/ai/AiClientConfig.kt
@@ -1,0 +1,57 @@
+package com.qawave.infrastructure.ai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.qawave.application.port.AiClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
+
+/**
+ * Configuration for AI clients.
+ */
+@Configuration
+class AiClientConfig {
+
+    @Bean
+    fun aiWebClient(
+        @Value("\${qawave.ai.base-url:https://api.openai.com}") baseUrl: String,
+        @Value("\${qawave.ai.timeout-seconds:60}") timeoutSeconds: Long
+    ): WebClient {
+        val httpClient = HttpClient.create()
+            .responseTimeout(Duration.ofSeconds(timeoutSeconds))
+
+        return WebClient.builder()
+            .baseUrl(baseUrl)
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .codecs { configurer ->
+                configurer.defaultCodecs().maxInMemorySize(16 * 1024 * 1024) // 16MB
+            }
+            .build()
+    }
+
+    @Bean
+    @Primary
+    @Profile("!test")
+    fun openAiClient(
+        webClient: WebClient,
+        objectMapper: ObjectMapper,
+        @Value("\${qawave.ai.api-key:}") apiKey: String,
+        @Value("\${qawave.ai.model:gpt-4o-mini}") model: String,
+        @Value("\${qawave.ai.base-url:https://api.openai.com}") baseUrl: String
+    ): AiClient {
+        return OpenAiClient(webClient, objectMapper, apiKey, model, baseUrl)
+    }
+
+    @Bean
+    @Primary
+    @Profile("test")
+    fun stubAiClient(): AiClient {
+        return StubAiClient()
+    }
+}

--- a/src/main/kotlin/com/qawave/infrastructure/ai/OpenAiClient.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/ai/OpenAiClient.kt
@@ -1,0 +1,225 @@
+package com.qawave.infrastructure.ai
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.qawave.application.port.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.awaitFirst
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.web.reactive.function.client.bodyToFlux
+
+/**
+ * OpenAI API client implementation.
+ * Uses Spring WebClient for non-blocking HTTP calls.
+ */
+@Component
+class OpenAiClient(
+    private val webClient: WebClient,
+    private val objectMapper: ObjectMapper,
+    @Value("\${qawave.ai.api-key:}") private val apiKey: String,
+    @Value("\${qawave.ai.model:gpt-4o-mini}") private val defaultModel: String,
+    @Value("\${qawave.ai.base-url:https://api.openai.com}") private val baseUrl: String
+) : AiClient {
+
+    private val logger = LoggerFactory.getLogger(OpenAiClient::class.java)
+
+    override val providerName: String = "openai"
+
+    override suspend fun complete(request: AiCompletionRequest): AiResponse {
+        logger.debug("Sending completion request to OpenAI: model={}", request.model ?: defaultModel)
+
+        val openAiRequest = buildRequest(request, stream = false)
+
+        try {
+            val response = webClient.post()
+                .uri("$baseUrl/v1/chat/completions")
+                .header("Authorization", "Bearer $apiKey")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(openAiRequest)
+                .retrieve()
+                .bodyToMono(OpenAiCompletionResponse::class.java)
+                .awaitFirst()
+
+            return mapResponse(response)
+        } catch (e: WebClientResponseException) {
+            throw mapException(e)
+        }
+    }
+
+    override fun streamComplete(request: AiCompletionRequest): Flow<AiResponseChunk> {
+        logger.debug("Starting streaming completion request to OpenAI")
+
+        val openAiRequest = buildRequest(request, stream = true)
+
+        return webClient.post()
+            .uri("$baseUrl/v1/chat/completions")
+            .header("Authorization", "Bearer $apiKey")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(openAiRequest)
+            .retrieve()
+            .bodyToFlux<String>()
+            .filter { line -> line.startsWith("data: ") && line != "data: [DONE]" }
+            .map { line ->
+                val jsonData = line.removePrefix("data: ")
+                try {
+                    val chunk: OpenAiStreamChunk = objectMapper.readValue(jsonData, OpenAiStreamChunk::class.java)
+                    val content = chunk.choices.firstOrNull()?.delta?.content ?: ""
+                    val finishReason = chunk.choices.firstOrNull()?.finishReason
+
+                    AiResponseChunk(
+                        content = content,
+                        isComplete = finishReason != null,
+                        finishReason = finishReason
+                    )
+                } catch (e: Exception) {
+                    logger.warn("Failed to parse stream chunk: {}", jsonData, e)
+                    AiResponseChunk(content = "", isComplete = false)
+                }
+            }
+            .asFlow()
+    }
+
+    override suspend fun healthCheck(): Boolean {
+        return try {
+            webClient.get()
+                .uri("$baseUrl/v1/models")
+                .header("Authorization", "Bearer $apiKey")
+                .retrieve()
+                .toBodilessEntity()
+                .awaitFirstOrNull()
+            true
+        } catch (e: Exception) {
+            logger.warn("OpenAI health check failed", e)
+            false
+        }
+    }
+
+    private fun buildRequest(request: AiCompletionRequest, stream: Boolean): OpenAiCompletionRequest {
+        val messages = listOf(
+            OpenAiMessage(role = "system", content = request.systemPrompt),
+            OpenAiMessage(role = "user", content = request.userPrompt)
+        )
+
+        return OpenAiCompletionRequest(
+            model = request.model ?: defaultModel,
+            messages = messages,
+            temperature = request.temperature,
+            maxTokens = request.maxTokens,
+            stream = stream,
+            responseFormat = if (request.responseFormat == ResponseFormat.JSON) {
+                OpenAiResponseFormat(type = "json_object")
+            } else null
+        )
+    }
+
+    private fun mapResponse(response: OpenAiCompletionResponse): AiResponse {
+        val choice = response.choices.firstOrNull()
+            ?: throw AiClientException("No choices in OpenAI response", provider = providerName)
+
+        return AiResponse(
+            content = choice.message.content,
+            model = response.model,
+            usage = response.usage?.let {
+                TokenUsage(
+                    promptTokens = it.promptTokens,
+                    completionTokens = it.completionTokens,
+                    totalTokens = it.totalTokens
+                )
+            },
+            finishReason = choice.finishReason,
+            metadata = mapOf("id" to response.id)
+        )
+    }
+
+    private fun mapException(e: WebClientResponseException): AiClientException {
+        return when (e.statusCode) {
+            HttpStatus.TOO_MANY_REQUESTS -> {
+                val retryAfter = e.headers.getFirst("Retry-After")?.toLongOrNull()?.times(1000)
+                AiRateLimitException(
+                    message = "OpenAI rate limit exceeded",
+                    retryAfterMs = retryAfter
+                )
+            }
+            HttpStatus.UNAUTHORIZED -> AiClientException(
+                message = "OpenAI authentication failed",
+                statusCode = 401,
+                provider = providerName
+            )
+            else -> AiClientException(
+                message = "OpenAI request failed: ${e.message}",
+                statusCode = e.statusCode.value(),
+                provider = providerName,
+                cause = e
+            )
+        }
+    }
+}
+
+// OpenAI API DTOs
+
+data class OpenAiCompletionRequest(
+    val model: String,
+    val messages: List<OpenAiMessage>,
+    val temperature: Double = 0.2,
+    @JsonProperty("max_tokens")
+    val maxTokens: Int = 4096,
+    val stream: Boolean = false,
+    @JsonProperty("response_format")
+    val responseFormat: OpenAiResponseFormat? = null
+)
+
+data class OpenAiMessage(
+    val role: String,
+    val content: String
+)
+
+data class OpenAiResponseFormat(
+    val type: String
+)
+
+data class OpenAiCompletionResponse(
+    val id: String,
+    val model: String,
+    val choices: List<OpenAiChoice>,
+    val usage: OpenAiUsage?
+)
+
+data class OpenAiChoice(
+    val index: Int,
+    val message: OpenAiMessage,
+    @JsonProperty("finish_reason")
+    val finishReason: String?
+)
+
+data class OpenAiUsage(
+    @JsonProperty("prompt_tokens")
+    val promptTokens: Int,
+    @JsonProperty("completion_tokens")
+    val completionTokens: Int,
+    @JsonProperty("total_tokens")
+    val totalTokens: Int
+)
+
+data class OpenAiStreamChunk(
+    val choices: List<OpenAiStreamChoice>
+)
+
+data class OpenAiStreamChoice(
+    val delta: OpenAiDelta,
+    @JsonProperty("finish_reason")
+    val finishReason: String?
+)
+
+data class OpenAiDelta(
+    val content: String?
+)

--- a/src/main/kotlin/com/qawave/infrastructure/ai/PromptTemplates.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/ai/PromptTemplates.kt
@@ -1,0 +1,191 @@
+package com.qawave.infrastructure.ai
+
+/**
+ * Prompt templates for AI-powered test generation and evaluation.
+ */
+object PromptTemplates {
+
+    /**
+     * System prompt for scenario generation.
+     */
+    val SCENARIO_GENERATOR_SYSTEM = """
+You are an expert QA engineer specialized in API testing. Your task is to generate comprehensive test scenarios from OpenAPI specifications and requirements.
+
+Guidelines:
+1. Create realistic, executable test scenarios
+2. Include both positive and negative test cases
+3. Chain related operations logically (e.g., create -> read -> update -> delete)
+4. Use JSONPath expressions for value extraction and assertions
+5. Include appropriate headers and authentication where needed
+6. Generate meaningful assertions for response validation
+
+Output Format (JSON):
+{
+  "scenarios": [
+    {
+      "name": "Descriptive scenario name",
+      "description": "What this scenario tests",
+      "steps": [
+        {
+          "index": 0,
+          "name": "Step name",
+          "method": "HTTP method",
+          "endpoint": "/api/path",
+          "headers": {"Header-Name": "value"},
+          "body": {"key": "value"},
+          "expected": {
+            "status": 200,
+            "bodyFields": {"field": "expected_value or <any>"}
+          },
+          "extractions": {"varName": "$.jsonpath"}
+        }
+      ]
+    }
+  ]
+}
+
+Important:
+- Use {varName} syntax for variable substitution in endpoints and bodies
+- Use <any> matcher for dynamic values like IDs
+- Include timeoutMs for slow operations
+- Test error cases with appropriate status codes (400, 401, 404, etc.)
+""".trimIndent()
+
+    /**
+     * User prompt template for scenario generation.
+     */
+    fun scenarioGeneratorUser(openApiSpec: String, requirements: String?, maxScenarios: Int): String = """
+Generate up to $maxScenarios test scenarios based on the following:
+
+OpenAPI Specification:
+```yaml
+$openApiSpec
+```
+
+${if (requirements != null) """
+Business Requirements:
+$requirements
+""" else ""}
+
+Focus on:
+1. Happy path scenarios covering main user flows
+2. Edge cases and boundary conditions
+3. Error handling scenarios
+4. Authentication/authorization if applicable
+
+Respond with valid JSON only.
+""".trimIndent()
+
+    /**
+     * System prompt for result evaluation.
+     */
+    val RESULT_EVALUATOR_SYSTEM = """
+You are an expert QA analyst reviewing test execution results. Your task is to evaluate test outcomes, identify issues, and provide actionable recommendations.
+
+Guidelines:
+1. Analyze passed and failed assertions objectively
+2. Identify patterns in failures
+3. Distinguish between bugs, test issues, and environment problems
+4. Provide clear, actionable recommendations
+5. Assess overall API quality and risk
+
+Output Format (JSON):
+{
+  "verdict": "PASS | PASS_WITH_WARNINGS | FAIL | ERROR | INCONCLUSIVE",
+  "summary": "Brief overall assessment",
+  "passedCount": 0,
+  "failedCount": 0,
+  "findings": [
+    {
+      "type": "BUG | REGRESSION | PERFORMANCE_ISSUE | SECURITY_CONCERN | DATA_INCONSISTENCY | API_CONTRACT_VIOLATION",
+      "severity": "INFO | LOW | MEDIUM | HIGH | CRITICAL",
+      "title": "Finding title",
+      "description": "Detailed description"
+    }
+  ],
+  "recommendations": [
+    {
+      "priority": "LOW | MEDIUM | HIGH | IMMEDIATE",
+      "title": "Recommendation title",
+      "description": "What should be done"
+    }
+  ],
+  "qualityScore": 0-100,
+  "stabilityScore": 0-100
+}
+""".trimIndent()
+
+    /**
+     * User prompt template for result evaluation.
+     */
+    fun resultEvaluatorUser(results: String, context: String?): String = """
+Evaluate the following test execution results:
+
+```json
+$results
+```
+
+${if (context != null) """
+Additional Context:
+$context
+""" else ""}
+
+Provide a comprehensive evaluation with:
+1. Overall verdict
+2. Key findings (bugs, issues, concerns)
+3. Prioritized recommendations
+4. Quality and stability scores
+
+Respond with valid JSON only.
+""".trimIndent()
+
+    /**
+     * System prompt for requirements analysis.
+     */
+    val REQUIREMENTS_ANALYZER_SYSTEM = """
+You are an expert business analyst specializing in extracting testable requirements from business documentation.
+
+Guidelines:
+1. Identify distinct user flows and journeys
+2. Extract acceptance criteria and success conditions
+3. Note any implicit requirements or edge cases
+4. Map requirements to potential API operations
+
+Output Format (JSON):
+{
+  "userFlows": [
+    {
+      "name": "Flow name",
+      "description": "What the user is trying to accomplish",
+      "steps": ["Step 1", "Step 2"],
+      "preconditions": ["Required state"],
+      "expectedOutcomes": ["Success criteria"]
+    }
+  ],
+  "acceptanceCriteria": [
+    {
+      "id": "AC-001",
+      "description": "Criterion description",
+      "testable": true
+    }
+  ],
+  "edgeCases": ["Edge case 1", "Edge case 2"]
+}
+""".trimIndent()
+
+    /**
+     * User prompt template for requirements analysis.
+     */
+    fun requirementsAnalyzerUser(requirements: String): String = """
+Analyze the following business requirements and extract testable elements:
+
+$requirements
+
+Provide:
+1. User flows with clear steps and expected outcomes
+2. Specific acceptance criteria
+3. Edge cases and boundary conditions to test
+
+Respond with valid JSON only.
+""".trimIndent()
+}

--- a/src/main/kotlin/com/qawave/infrastructure/ai/StubAiClient.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/ai/StubAiClient.kt
@@ -1,0 +1,166 @@
+package com.qawave.infrastructure.ai
+
+import com.qawave.application.port.*
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.slf4j.LoggerFactory
+
+/**
+ * Stub AI client for testing and development.
+ * Returns predefined responses without calling any external API.
+ */
+class StubAiClient(
+    private val simulatedDelayMs: Long = 100,
+    private val defaultResponse: String = DEFAULT_RESPONSE
+) : AiClient {
+
+    private val logger = LoggerFactory.getLogger(StubAiClient::class.java)
+
+    override val providerName: String = "stub"
+
+    private var responseOverride: String? = null
+    private var shouldFail: Boolean = false
+    private var failureException: AiClientException? = null
+
+    /**
+     * Sets a custom response for the next request.
+     */
+    fun setNextResponse(response: String) {
+        this.responseOverride = response
+    }
+
+    /**
+     * Configures the client to fail on the next request.
+     */
+    fun setNextFailure(exception: AiClientException) {
+        this.shouldFail = true
+        this.failureException = exception
+    }
+
+    /**
+     * Resets the client to default behavior.
+     */
+    fun reset() {
+        responseOverride = null
+        shouldFail = false
+        failureException = null
+    }
+
+    override suspend fun complete(request: AiCompletionRequest): AiResponse {
+        logger.debug("StubAiClient handling completion request")
+
+        // Simulate network delay
+        delay(simulatedDelayMs)
+
+        // Check for configured failure
+        if (shouldFail) {
+            shouldFail = false
+            throw failureException ?: AiClientException("Stub failure", provider = providerName)
+        }
+
+        val content = responseOverride ?: generateResponse(request)
+        responseOverride = null
+
+        return AiResponse(
+            content = content,
+            model = "stub-model",
+            usage = TokenUsage(
+                promptTokens = request.systemPrompt.length + request.userPrompt.length,
+                completionTokens = content.length,
+                totalTokens = request.systemPrompt.length + request.userPrompt.length + content.length
+            ),
+            finishReason = "stop",
+            metadata = mapOf("provider" to "stub")
+        )
+    }
+
+    override fun streamComplete(request: AiCompletionRequest): Flow<AiResponseChunk> = flow {
+        logger.debug("StubAiClient handling streaming completion request")
+
+        // Simulate network delay
+        delay(simulatedDelayMs)
+
+        if (shouldFail) {
+            shouldFail = false
+            throw failureException ?: AiClientException("Stub failure", provider = providerName)
+        }
+
+        val content = responseOverride ?: generateResponse(request)
+        responseOverride = null
+
+        // Stream word by word
+        val words = content.split(" ")
+        words.forEachIndexed { index, word ->
+            delay(10) // Simulate streaming delay
+            emit(AiResponseChunk(
+                content = if (index > 0) " $word" else word,
+                isComplete = index == words.lastIndex,
+                finishReason = if (index == words.lastIndex) "stop" else null
+            ))
+        }
+    }
+
+    override suspend fun healthCheck(): Boolean {
+        return true
+    }
+
+    private fun generateResponse(request: AiCompletionRequest): String {
+        // Check if the request is for JSON format
+        if (request.responseFormat == ResponseFormat.JSON) {
+            return when {
+                request.userPrompt.contains("scenario", ignoreCase = true) -> STUB_SCENARIO_JSON
+                request.userPrompt.contains("evaluate", ignoreCase = true) -> STUB_EVALUATION_JSON
+                else -> """{"message": "Stub response"}"""
+            }
+        }
+        return defaultResponse
+    }
+
+    companion object {
+        const val DEFAULT_RESPONSE = "This is a stub response from the AI client."
+
+        const val STUB_SCENARIO_JSON = """
+{
+  "name": "User Registration Flow",
+  "description": "Tests the user registration process",
+  "steps": [
+    {
+      "index": 0,
+      "name": "Create new user",
+      "method": "POST",
+      "endpoint": "/api/users",
+      "headers": {"Content-Type": "application/json"},
+      "body": {"email": "test@example.com", "password": "secret123"},
+      "expected": {
+        "status": 201,
+        "bodyFields": {"id": "<any>", "email": "test@example.com"}
+      },
+      "extractions": {"userId": "$.id"}
+    },
+    {
+      "index": 1,
+      "name": "Get user by ID",
+      "method": "GET",
+      "endpoint": "/api/users/{userId}",
+      "expected": {
+        "status": 200,
+        "bodyFields": {"email": "test@example.com"}
+      }
+    }
+  ]
+}
+"""
+
+        const val STUB_EVALUATION_JSON = """
+{
+  "verdict": "PASS",
+  "summary": "All tests passed successfully",
+  "passedCount": 2,
+  "failedCount": 0,
+  "findings": [],
+  "recommendations": []
+}
+"""
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,9 +40,11 @@ qawave:
     provider: ${AI_PROVIDER:openai}
     api-key: ${AI_API_KEY:}
     model: ${AI_MODEL:gpt-4o-mini}
+    base-url: ${AI_BASE_URL:https://api.openai.com}
     temperature: 0.2
     max-attempts: 3
     concurrency-limit: 5
+    timeout-seconds: 60
   execution:
     timeout-max-ms: 300000
     timeout-default-ms: 30000


### PR DESCRIPTION
## Summary
- Created AiClient port interface for AI provider abstraction
- Implemented OpenAiClient with Spring WebClient
- Added StubAiClient for testing
- Created prompt templates for scenario generation and evaluation

## Acceptance Criteria
- [x] AiClient interface with suspend functions
- [x] OpenAiClient implementation
- [ ] VeniceClient implementation (deferred - separate issue)
- [x] StubAiClient for testing
- [x] Prompt templates for scenario generation
- [x] Response parsing to domain objects

## Features
- **Non-blocking HTTP**: Uses Spring WebClient for reactive calls
- **Streaming Support**: Server-Sent Events via Kotlin Flow
- **JSON Mode**: Structured output support
- **Error Handling**: Custom exceptions for rate limits, auth, timeouts
- **Configuration**: Profile-based provider selection (test/prod)

## Test Plan
- [x] Build succeeds
- [x] All existing tests pass
- [ ] Unit tests for AI client (to be added in follow-up)
- [ ] Integration tests with mock server (to be added)

## Dependencies
This PR depends on PR #41 (Spring Boot initialization).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)