### PR TITLE
[Backend] feat: configure Spring Data Redis with reactive Lettuce client (#29)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.apache.commons:commons-pool2:2.12.0")
 
     // Kafka
     implementation("org.springframework.kafka:spring-kafka")
@@ -71,8 +72,10 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:postgresql")
     testImplementation("org.testcontainers:kafka")
+    testImplementation("com.redis:testcontainers-redis:2.2.2")
     testImplementation("org.testcontainers:r2dbc")
     testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
 
     // H2 for testing
     testRuntimeOnly("io.r2dbc:r2dbc-h2")

--- a/src/main/kotlin/com/qawave/infrastructure/cache/CacheService.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/cache/CacheService.kt
@@ -1,0 +1,202 @@
+package com.qawave.infrastructure.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlinx.coroutines.reactive.awaitFirstOrNull
+import kotlinx.coroutines.reactive.awaitSingle
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+/**
+ * Cache key prefixes for different entity types.
+ */
+object CacheKeys {
+    const val QA_PACKAGE = "qawave:package:"
+    const val SCENARIO = "qawave:scenario:"
+    const val TEST_RUN = "qawave:run:"
+    const val API_SPEC = "qawave:spec:"
+    const val AI_RESPONSE = "qawave:ai:"
+
+    fun qaPackage(id: String) = "$QA_PACKAGE$id"
+    fun scenario(id: String) = "$SCENARIO$id"
+    fun testRun(id: String) = "$TEST_RUN$id"
+    fun apiSpec(hash: String) = "$API_SPEC$hash"
+    fun aiResponse(hash: String) = "$AI_RESPONSE$hash"
+}
+
+/**
+ * Default TTL values for different cache types.
+ */
+object CacheTtl {
+    val QA_PACKAGE: Duration = Duration.ofMinutes(30)
+    val SCENARIO: Duration = Duration.ofMinutes(60)
+    val TEST_RUN: Duration = Duration.ofMinutes(15)
+    val API_SPEC: Duration = Duration.ofHours(24)
+    val AI_RESPONSE: Duration = Duration.ofHours(12)
+}
+
+/**
+ * Service for caching operations using reactive Redis.
+ * Provides type-safe caching with automatic JSON serialization.
+ */
+@Service
+class CacheService(
+    private val redisTemplate: ReactiveRedisTemplate<String, Any>,
+    private val stringRedisTemplate: ReactiveRedisTemplate<String, String>,
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(CacheService::class.java)
+
+    /**
+     * Gets a cached value by key with type conversion.
+     * @param key The cache key
+     * @param type The class type to deserialize to
+     */
+    suspend fun <T> get(key: String, type: Class<T>): T? {
+        return try {
+            val value = stringRedisTemplate.opsForValue()
+                .get(key)
+                .awaitFirstOrNull()
+
+            value?.let { objectMapper.readValue(it, type) }
+        } catch (e: Exception) {
+            logger.warn("Cache get failed for key '{}': {}", key, e.message)
+            null
+        }
+    }
+
+    /**
+     * Sets a cached value with the specified TTL.
+     */
+    suspend fun <T : Any> set(key: String, value: T, ttl: Duration): Boolean {
+        return try {
+            val json = objectMapper.writeValueAsString(value)
+            stringRedisTemplate.opsForValue()
+                .set(key, json, ttl)
+                .awaitSingle()
+        } catch (e: Exception) {
+            logger.warn("Cache set failed for key '{}': {}", key, e.message)
+            false
+        }
+    }
+
+    /**
+     * Gets a cached value or computes it if not present.
+     * @param key The cache key
+     * @param type The class type to deserialize to
+     * @param ttl Time to live for the cached value
+     * @param compute Function to compute the value if not cached
+     */
+    suspend fun <T : Any> getOrSet(
+        key: String,
+        type: Class<T>,
+        ttl: Duration,
+        compute: suspend () -> T?
+    ): T? {
+        val cached = get(key, type)
+        if (cached != null) {
+            logger.debug("Cache hit for key '{}'", key)
+            return cached
+        }
+
+        logger.debug("Cache miss for key '{}'", key)
+        val computed = compute()
+        if (computed != null) {
+            set(key, computed, ttl)
+        }
+        return computed
+    }
+
+    /**
+     * Deletes a cached value by key.
+     */
+    suspend fun delete(key: String): Boolean {
+        return try {
+            stringRedisTemplate.delete(key).awaitSingle() > 0
+        } catch (e: Exception) {
+            logger.warn("Cache delete failed for key '{}': {}", key, e.message)
+            false
+        }
+    }
+
+    /**
+     * Deletes all cached values matching a pattern.
+     */
+    suspend fun deleteByPattern(pattern: String): Long {
+        return try {
+            val keys = stringRedisTemplate.keys(pattern)
+            stringRedisTemplate.delete(keys).awaitSingle()
+        } catch (e: Exception) {
+            logger.warn("Cache delete by pattern failed for '{}': {}", pattern, e.message)
+            0
+        }
+    }
+
+    /**
+     * Checks if a key exists in the cache.
+     */
+    suspend fun exists(key: String): Boolean {
+        return try {
+            stringRedisTemplate.hasKey(key).awaitSingle()
+        } catch (e: Exception) {
+            logger.warn("Cache exists check failed for key '{}': {}", key, e.message)
+            false
+        }
+    }
+
+    /**
+     * Gets the TTL for a key.
+     */
+    suspend fun getTtl(key: String): Duration? {
+        return try {
+            val ttl = stringRedisTemplate.getExpire(key).awaitFirstOrNull()
+            ttl?.let { Duration.ofSeconds(it.seconds) }
+        } catch (e: Exception) {
+            logger.warn("Cache TTL check failed for key '{}': {}", key, e.message)
+            null
+        }
+    }
+
+    /**
+     * Extends the TTL for a key.
+     */
+    suspend fun expire(key: String, ttl: Duration): Boolean {
+        return try {
+            stringRedisTemplate.expire(key, ttl).awaitSingle()
+        } catch (e: Exception) {
+            logger.warn("Cache expire failed for key '{}': {}", key, e.message)
+            false
+        }
+    }
+
+    /**
+     * Increments a counter value.
+     */
+    suspend fun increment(key: String, delta: Long = 1): Long? {
+        return try {
+            redisTemplate.opsForValue()
+                .increment(key, delta)
+                .awaitFirstOrNull()
+        } catch (e: Exception) {
+            logger.warn("Cache increment failed for key '{}': {}", key, e.message)
+            null
+        }
+    }
+
+    /**
+     * Health check for Redis connection.
+     */
+    suspend fun ping(): Boolean {
+        return try {
+            val result = stringRedisTemplate.connectionFactory
+                .reactiveConnection
+                .ping()
+                .awaitFirstOrNull()
+            result == "PONG"
+        } catch (e: Exception) {
+            logger.error("Redis health check failed: {}", e.message)
+            false
+        }
+    }
+}

--- a/src/main/kotlin/com/qawave/infrastructure/cache/RedisConfig.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/cache/RedisConfig.kt
@@ -1,0 +1,117 @@
+package com.qawave.infrastructure.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettucePoolingClientConfiguration
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+/**
+ * Configuration for reactive Redis with Lettuce client.
+ * Provides connection pooling and JSON serialization.
+ */
+@Configuration
+class RedisConfig(
+    private val objectMapper: ObjectMapper
+) {
+
+    @Value("\${spring.data.redis.host:localhost}")
+    private lateinit var redisHost: String
+
+    @Value("\${spring.data.redis.port:6379}")
+    private var redisPort: Int = 6379
+
+    @Value("\${spring.data.redis.password:}")
+    private lateinit var redisPassword: String
+
+    @Value("\${qawave.cache.pool.min-idle:2}")
+    private var poolMinIdle: Int = 2
+
+    @Value("\${qawave.cache.pool.max-idle:8}")
+    private var poolMaxIdle: Int = 8
+
+    @Value("\${qawave.cache.pool.max-active:16}")
+    private var poolMaxActive: Int = 16
+
+    @Value("\${qawave.cache.command-timeout:5000}")
+    private var commandTimeout: Long = 5000
+
+    /**
+     * Creates a Lettuce connection factory with pooling configuration.
+     */
+    @Bean
+    @Primary
+    fun reactiveRedisConnectionFactory(): ReactiveRedisConnectionFactory {
+        val serverConfig = RedisStandaloneConfiguration(redisHost, redisPort).apply {
+            if (redisPassword.isNotBlank()) {
+                setPassword(redisPassword)
+            }
+        }
+
+        val clientConfig = LettucePoolingClientConfiguration.builder()
+            .commandTimeout(Duration.ofMillis(commandTimeout))
+            .poolConfig(buildPoolConfig())
+            .build()
+
+        return LettuceConnectionFactory(serverConfig, clientConfig)
+    }
+
+    /**
+     * Creates a reactive Redis template with JSON serialization.
+     */
+    @Bean
+    fun reactiveRedisTemplate(
+        connectionFactory: ReactiveRedisConnectionFactory
+    ): ReactiveRedisTemplate<String, Any> {
+        val keySerializer = StringRedisSerializer()
+        val valueSerializer = Jackson2JsonRedisSerializer(objectMapper, Any::class.java)
+
+        val serializationContext = RedisSerializationContext.newSerializationContext<String, Any>()
+            .key(keySerializer)
+            .value(valueSerializer)
+            .hashKey(keySerializer)
+            .hashValue(valueSerializer)
+            .build()
+
+        return ReactiveRedisTemplate(connectionFactory, serializationContext)
+    }
+
+    /**
+     * Creates a string-only reactive Redis template for simple caching.
+     */
+    @Bean
+    fun reactiveStringRedisTemplate(
+        connectionFactory: ReactiveRedisConnectionFactory
+    ): ReactiveRedisTemplate<String, String> {
+        val serializer = StringRedisSerializer()
+
+        val serializationContext = RedisSerializationContext.newSerializationContext<String, String>()
+            .key(serializer)
+            .value(serializer)
+            .hashKey(serializer)
+            .hashValue(serializer)
+            .build()
+
+        return ReactiveRedisTemplate(connectionFactory, serializationContext)
+    }
+
+    private fun buildPoolConfig(): org.apache.commons.pool2.impl.GenericObjectPoolConfig<Any> {
+        return org.apache.commons.pool2.impl.GenericObjectPoolConfig<Any>().apply {
+            minIdle = poolMinIdle
+            maxIdle = poolMaxIdle
+            maxTotal = poolMaxActive
+            testOnBorrow = true
+            testWhileIdle = true
+        }
+    }
+}

--- a/src/main/kotlin/com/qawave/infrastructure/cache/RedisHealthIndicator.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/cache/RedisHealthIndicator.kt
@@ -1,0 +1,37 @@
+package com.qawave.infrastructure.cache
+
+import kotlinx.coroutines.reactor.mono
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.ReactiveHealthIndicator
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+/**
+ * Health indicator for Redis connection.
+ * Reports Redis status in the actuator health endpoint.
+ */
+@Component
+class RedisHealthIndicator(
+    private val cacheService: CacheService
+) : ReactiveHealthIndicator {
+
+    override fun health(): Mono<Health> = mono {
+        try {
+            val isHealthy = cacheService.ping()
+            if (isHealthy) {
+                Health.up()
+                    .withDetail("status", "Connected")
+                    .build()
+            } else {
+                Health.down()
+                    .withDetail("status", "Ping failed")
+                    .build()
+            }
+        } catch (e: Exception) {
+            Health.down()
+                .withDetail("status", "Error")
+                .withDetail("error", e.message ?: "Unknown error")
+                .build()
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,12 @@ qawave:
   validation:
     max-openapi-length: 100000
     max-scenario-json-size-bytes: 5242880
+  cache:
+    pool:
+      min-idle: 2
+      max-idle: 8
+      max-active: 16
+    command-timeout: 5000
 
 management:
   endpoints:

--- a/src/test/kotlin/com/qawave/integration/RedisIntegrationTest.kt
+++ b/src/test/kotlin/com/qawave/integration/RedisIntegrationTest.kt
@@ -1,0 +1,207 @@
+package com.qawave.integration
+
+import com.qawave.infrastructure.cache.CacheKeys
+import com.qawave.infrastructure.cache.CacheService
+import com.qawave.infrastructure.cache.CacheTtl
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for Redis caching with Testcontainers.
+ */
+@SpringBootTest
+@Testcontainers
+class RedisIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redisContainer: GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+
+        @DynamicPropertySource
+        @JvmStatic
+        fun configureProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.host") { redisContainer.host }
+            registry.add("spring.data.redis.port") { redisContainer.getMappedPort(6379) }
+            // Disable R2DBC auto-config for this test
+            registry.add("spring.r2dbc.url") { "r2dbc:h2:mem:///testdb;DB_CLOSE_DELAY=-1" }
+            registry.add("spring.r2dbc.username") { "sa" }
+            registry.add("spring.r2dbc.password") { "" }
+        }
+    }
+
+    @Autowired
+    private lateinit var cacheService: CacheService
+
+    @BeforeEach
+    fun setup() {
+        runBlocking {
+            // Clear test keys before each test
+            cacheService.deleteByPattern("qawave:test:*")
+        }
+    }
+
+    @Test
+    fun `should connect to Redis and respond to ping`() = runBlocking {
+        val isHealthy = cacheService.ping()
+        assertTrue(isHealthy, "Redis should be healthy")
+    }
+
+    @Test
+    fun `should set and get string value`() = runBlocking {
+        val key = "qawave:test:string"
+        val value = "hello-world"
+
+        val setResult = cacheService.set(key, value, Duration.ofMinutes(5))
+        assertTrue(setResult, "Set should succeed")
+
+        val retrieved = cacheService.get(key, String::class.java)
+        assertEquals(value, retrieved, "Retrieved value should match")
+    }
+
+    @Test
+    fun `should set and get complex object`() = runBlocking {
+        val key = "qawave:test:object"
+        val value = TestCacheObject(
+            id = "test-123",
+            name = "Test Object",
+            count = 42
+        )
+
+        val setResult = cacheService.set(key, value, Duration.ofMinutes(5))
+        assertTrue(setResult, "Set should succeed")
+
+        val retrieved = cacheService.get(key, TestCacheObject::class.java)
+        assertNotNull(retrieved, "Retrieved value should not be null")
+        assertEquals(value.id, retrieved.id)
+        assertEquals(value.name, retrieved.name)
+        assertEquals(value.count, retrieved.count)
+    }
+
+    @Test
+    fun `should return null for non-existent key`() = runBlocking {
+        val key = "qawave:test:non-existent"
+        val retrieved = cacheService.get(key, String::class.java)
+        assertNull(retrieved, "Non-existent key should return null")
+    }
+
+    @Test
+    fun `should delete key`() = runBlocking {
+        val key = "qawave:test:delete"
+        cacheService.set(key, "to-be-deleted", Duration.ofMinutes(5))
+
+        assertTrue(cacheService.exists(key), "Key should exist before delete")
+
+        val deleted = cacheService.delete(key)
+        assertTrue(deleted, "Delete should succeed")
+
+        assertFalse(cacheService.exists(key), "Key should not exist after delete")
+    }
+
+    @Test
+    fun `should delete keys by pattern`() = runBlocking {
+        cacheService.set("qawave:test:pattern:1", "value1", Duration.ofMinutes(5))
+        cacheService.set("qawave:test:pattern:2", "value2", Duration.ofMinutes(5))
+        cacheService.set("qawave:test:other:1", "other", Duration.ofMinutes(5))
+
+        val deleted = cacheService.deleteByPattern("qawave:test:pattern:*")
+        assertEquals(2, deleted, "Should delete 2 keys matching pattern")
+
+        assertFalse(cacheService.exists("qawave:test:pattern:1"))
+        assertFalse(cacheService.exists("qawave:test:pattern:2"))
+        assertTrue(cacheService.exists("qawave:test:other:1"))
+    }
+
+    @Test
+    fun `should use getOrSet for cache-aside pattern`() = runBlocking {
+        val key = "qawave:test:cache-aside"
+        var computeCount = 0
+
+        val result1 = cacheService.getOrSet(key, String::class.java, Duration.ofMinutes(5)) {
+            computeCount++
+            "computed-value"
+        }
+
+        assertEquals("computed-value", result1)
+        assertEquals(1, computeCount, "Should compute once on cache miss")
+
+        val result2 = cacheService.getOrSet(key, String::class.java, Duration.ofMinutes(5)) {
+            computeCount++
+            "computed-value-2"
+        }
+
+        assertEquals("computed-value", result2, "Should return cached value")
+        assertEquals(1, computeCount, "Should not compute again on cache hit")
+    }
+
+    @Test
+    fun `should increment counter`() = runBlocking {
+        val key = "qawave:test:counter"
+
+        val first = cacheService.increment(key)
+        assertEquals(1, first)
+
+        val second = cacheService.increment(key)
+        assertEquals(2, second)
+
+        val third = cacheService.increment(key, 5)
+        assertEquals(7, third)
+    }
+
+    @Test
+    fun `should expire key`() = runBlocking {
+        val key = "qawave:test:expire"
+        cacheService.set(key, "value", Duration.ofMinutes(5))
+
+        val newTtl = Duration.ofSeconds(10)
+        val expired = cacheService.expire(key, newTtl)
+        assertTrue(expired, "Expire should succeed")
+
+        val ttl = cacheService.getTtl(key)
+        assertNotNull(ttl, "TTL should be returned")
+        assertTrue(ttl.seconds <= 10, "TTL should be updated")
+    }
+
+    @Test
+    fun `cache keys should generate correct prefixes`() {
+        assertEquals("qawave:package:123", CacheKeys.qaPackage("123"))
+        assertEquals("qawave:scenario:456", CacheKeys.scenario("456"))
+        assertEquals("qawave:run:789", CacheKeys.testRun("789"))
+        assertEquals("qawave:spec:abc", CacheKeys.apiSpec("abc"))
+        assertEquals("qawave:ai:def", CacheKeys.aiResponse("def"))
+    }
+
+    @Test
+    fun `cache TTL constants should have sensible values`() {
+        assertTrue(CacheTtl.QA_PACKAGE.toMinutes() > 0)
+        assertTrue(CacheTtl.SCENARIO.toMinutes() > 0)
+        assertTrue(CacheTtl.TEST_RUN.toMinutes() > 0)
+        assertTrue(CacheTtl.API_SPEC.toHours() > 0)
+        assertTrue(CacheTtl.AI_RESPONSE.toHours() > 0)
+    }
+
+    /**
+     * Test data class for object caching tests.
+     */
+    data class TestCacheObject(
+        val id: String,
+        val name: String,
+        val count: Int
+    )
+}


### PR DESCRIPTION
## Summary

- Configure reactive Redis with Lettuce client and connection pooling
- Create `CacheService` for type-safe caching operations with JSON serialization
- Add `CacheKeys` object with standardized key prefixes for different entity types
- Add `CacheTtl` object with default TTL values for different cache types
- Implement `RedisHealthIndicator` for Spring Boot Actuator health endpoint

## Features

### CacheService Methods
- `get(key, type)` - Retrieve cached value with type conversion
- `set(key, value, ttl)` - Store value with TTL
- `getOrSet(key, type, ttl, compute)` - Cache-aside pattern
- `delete(key)` - Delete single key
- `deleteByPattern(pattern)` - Delete keys matching pattern
- `exists(key)` - Check key existence
- `getTtl(key)` - Get remaining TTL
- `expire(key, ttl)` - Update TTL
- `increment(key, delta)` - Atomic increment
- `ping()` - Health check

### Configuration
- Connection pooling with configurable min/max idle and max active
- Command timeout configuration
- JSON serialization with Jackson

## Test Plan

- [x] Build succeeds (`./gradlew build`)
- [x] All tests pass including Redis integration tests with Testcontainers
- [ ] Health endpoint shows Redis status at `/actuator/health`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)