### PR TITLE
[Backend] feat: create OpenAPI specification with Swagger UI (#32)

### DIFF
--- a/src/main/kotlin/com/qawave/infrastructure/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/config/OpenApiConfig.kt
@@ -1,0 +1,79 @@
+package com.qawave.infrastructure.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.oas.models.tags.Tag
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Configuration for OpenAPI/Swagger documentation.
+ */
+@Configuration
+class OpenApiConfig {
+
+    @Value("\${server.port:8080}")
+    private var serverPort: Int = 8080
+
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        return OpenAPI()
+            .info(apiInfo())
+            .servers(listOf(
+                Server()
+                    .url("http://localhost:$serverPort")
+                    .description("Local development server"),
+                Server()
+                    .url("https://api.qawave.com")
+                    .description("Production server")
+            ))
+            .tags(listOf(
+                Tag()
+                    .name("QA Packages")
+                    .description("Operations for managing QA test packages"),
+                Tag()
+                    .name("Test Scenarios")
+                    .description("Operations for managing test scenarios"),
+                Tag()
+                    .name("Test Runs")
+                    .description("Operations for managing test execution runs"),
+                Tag()
+                    .name("Health")
+                    .description("Health and status endpoints")
+            ))
+    }
+
+    private fun apiInfo(): Info {
+        return Info()
+            .title("QAWave API")
+            .description("""
+                QAWave is an AI-powered QA automation platform that acts as a virtual QA engineering team for backend APIs.
+
+                ## Features
+                - Automated test scenario generation from OpenAPI specs
+                - AI-powered test execution and validation
+                - Comprehensive coverage reporting
+                - Risk assessment and quality scoring
+
+                ## Authentication
+                API authentication is handled via API keys passed in the `X-API-Key` header.
+
+                ## Rate Limiting
+                The API implements rate limiting to ensure fair usage. Current limits:
+                - 100 requests per minute per API key
+                - 10 concurrent AI generation requests
+            """.trimIndent())
+            .version("1.0.0")
+            .contact(Contact()
+                .name("QAWave Team")
+                .email("support@qawave.com")
+                .url("https://qawave.com"))
+            .license(License()
+                .name("Proprietary")
+                .url("https://qawave.com/terms"))
+    }
+}

--- a/src/main/kotlin/com/qawave/presentation/controller/OpenApiController.kt
+++ b/src/main/kotlin/com/qawave/presentation/controller/OpenApiController.kt
@@ -1,0 +1,73 @@
+package com.qawave.presentation.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.core.publisher.Mono
+
+/**
+ * Controller for OpenAPI documentation utilities.
+ */
+@RestController
+@RequestMapping("/api/docs")
+@Tag(name = "Documentation", description = "API documentation utilities")
+class OpenApiController {
+
+    @GetMapping("/info")
+    @Operation(
+        summary = "Get API documentation info",
+        description = "Returns information about where to access API documentation"
+    )
+    @ApiResponse(responseCode = "200", description = "Documentation info returned")
+    suspend fun getDocInfo(): ResponseEntity<ApiDocsInfo> {
+        return ResponseEntity.ok(ApiDocsInfo(
+            swaggerUi = "/swagger-ui.html",
+            apiDocs = "/api-docs",
+            apiDocsYaml = "/api-docs.yaml",
+            version = "1.0.0"
+        ))
+    }
+}
+
+/**
+ * Response DTO for API documentation info.
+ */
+data class ApiDocsInfo(
+    val swaggerUi: String,
+    val apiDocs: String,
+    val apiDocsYaml: String,
+    val version: String
+)
+
+/**
+ * Configuration for API grouping in OpenAPI.
+ */
+@Configuration
+class OpenApiGroupConfig {
+
+    @Bean
+    fun publicApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("public")
+            .packagesToScan("com.qawave.presentation.controller")
+            .pathsToMatch("/api/**")
+            .build()
+    }
+
+    @Bean
+    fun actuatorApi(): GroupedOpenApi {
+        return GroupedOpenApi.builder()
+            .group("actuator")
+            .pathsToMatch("/actuator/**")
+            .build()
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,17 @@ management:
 server:
   port: 8080
 
+springdoc:
+  api-docs:
+    path: /api-docs
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui
+    enabled: true
+    operations-sorter: method
+    tags-sorter: alpha
+  show-actuator: true
+
 logging:
   level:
     com.qawave: DEBUG


### PR DESCRIPTION
## Summary

- Configure Springdoc OpenAPI for Spring WebFlux
- Add comprehensive API metadata and documentation
- Create Swagger UI accessible at `/swagger-ui.html`
- Add API grouping for public and actuator endpoints

## Documentation Endpoints

| Endpoint | Description |
|----------|-------------|
| `/swagger-ui.html` | Interactive Swagger UI |
| `/api-docs` | OpenAPI 3.0 JSON specification |
| `/api-docs.yaml` | OpenAPI 3.0 YAML specification |
| `/api/docs/info` | Documentation info endpoint |

## Features

- API metadata with title, description, version, and contact info
- Server definitions for local and production environments
- Tag-based API grouping for better organization
- Operations sorted by method, tags sorted alphabetically

## Test Plan

- [x] Build succeeds (`./gradlew build`)
- [x] All tests pass (`./gradlew test`)
- [ ] Swagger UI accessible at http://localhost:8080/swagger-ui.html
- [ ] OpenAPI spec downloadable at http://localhost:8080/api-docs.yaml

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)