### PR TITLE
[Backend] feat: implement ScenarioService (#83)

### DIFF
--- a/src/main/kotlin/com/qawave/application/service/ScenarioService.kt
+++ b/src/main/kotlin/com/qawave/application/service/ScenarioService.kt
@@ -1,0 +1,242 @@
+package com.qawave.application.service
+
+import com.qawave.domain.model.*
+import kotlinx.coroutines.flow.Flow
+import java.time.Instant
+
+/**
+ * Service interface for Test Scenario operations.
+ * Provides business logic for creating, managing, and querying test scenarios.
+ */
+interface ScenarioService {
+
+    /**
+     * Creates a new test scenario.
+     *
+     * @param command The creation command with all required data
+     * @return The created scenario
+     */
+    suspend fun create(command: CreateScenarioCommand): TestScenario
+
+    /**
+     * Creates multiple scenarios in batch.
+     *
+     * @param commands List of creation commands
+     * @return List of created scenarios
+     */
+    suspend fun createBatch(commands: List<CreateScenarioCommand>): List<TestScenario>
+
+    /**
+     * Finds a scenario by its ID.
+     *
+     * @param id The scenario ID
+     * @return The scenario if found, null otherwise
+     */
+    suspend fun findById(id: ScenarioId): TestScenario?
+
+    /**
+     * Lists all scenarios with pagination.
+     *
+     * @param page The page number (0-indexed)
+     * @param size The page size
+     * @return A page of scenarios
+     */
+    suspend fun findAll(page: Int = 0, size: Int = 20): Page<TestScenario>
+
+    /**
+     * Streams all scenarios.
+     *
+     * @return A Flow of scenarios
+     */
+    fun findAllStream(): Flow<TestScenario>
+
+    /**
+     * Finds scenarios belonging to a QA package.
+     *
+     * @param packageId The QA package ID
+     * @return List of scenarios for the package
+     */
+    suspend fun findByPackageId(packageId: QaPackageId): List<TestScenario>
+
+    /**
+     * Streams scenarios belonging to a QA package.
+     *
+     * @param packageId The QA package ID
+     * @return Flow of scenarios for the package
+     */
+    fun findByPackageIdStream(packageId: QaPackageId): Flow<TestScenario>
+
+    /**
+     * Finds scenarios belonging to a test suite.
+     *
+     * @param suiteId The test suite ID
+     * @return List of scenarios for the suite
+     */
+    suspend fun findBySuiteId(suiteId: TestSuiteId): List<TestScenario>
+
+    /**
+     * Finds scenarios by status.
+     *
+     * @param status The status to filter by
+     * @return List of scenarios with the given status
+     */
+    suspend fun findByStatus(status: ScenarioStatus): List<TestScenario>
+
+    /**
+     * Streams scenarios by status.
+     *
+     * @param status The status to filter by
+     * @return Flow of scenarios with the given status
+     */
+    fun findByStatusStream(status: ScenarioStatus): Flow<TestScenario>
+
+    /**
+     * Finds scenarios by source type.
+     *
+     * @param source The source type
+     * @return List of scenarios from the given source
+     */
+    suspend fun findBySource(source: ScenarioSource): List<TestScenario>
+
+    /**
+     * Finds scenarios created after a specific time.
+     *
+     * @param since The cutoff time
+     * @return Flow of recent scenarios
+     */
+    fun findRecent(since: Instant): Flow<TestScenario>
+
+    /**
+     * Finds scenarios by tag.
+     *
+     * @param tag The tag to search for
+     * @return Flow of scenarios with the tag
+     */
+    fun findByTag(tag: String): Flow<TestScenario>
+
+    /**
+     * Updates a scenario.
+     *
+     * @param id The scenario ID
+     * @param command The update command
+     * @return The updated scenario
+     */
+    suspend fun update(id: ScenarioId, command: UpdateScenarioCommand): TestScenario
+
+    /**
+     * Updates the status of a scenario.
+     *
+     * @param id The scenario ID
+     * @param status The new status
+     * @return The updated scenario
+     */
+    suspend fun updateStatus(id: ScenarioId, status: ScenarioStatus): TestScenario
+
+    /**
+     * Marks a scenario as ready for execution.
+     *
+     * @param id The scenario ID
+     * @return The updated scenario
+     */
+    suspend fun markReady(id: ScenarioId): TestScenario
+
+    /**
+     * Marks a scenario as invalid.
+     *
+     * @param id The scenario ID
+     * @return The updated scenario
+     */
+    suspend fun markInvalid(id: ScenarioId): TestScenario
+
+    /**
+     * Disables a scenario.
+     *
+     * @param id The scenario ID
+     * @return The updated scenario
+     */
+    suspend fun disable(id: ScenarioId): TestScenario
+
+    /**
+     * Enables a disabled scenario.
+     *
+     * @param id The scenario ID
+     * @return The updated scenario
+     */
+    suspend fun enable(id: ScenarioId): TestScenario
+
+    /**
+     * Deletes a scenario.
+     *
+     * @param id The scenario ID
+     * @return true if deleted, false if not found
+     */
+    suspend fun delete(id: ScenarioId): Boolean
+
+    /**
+     * Deletes all scenarios for a QA package.
+     *
+     * @param packageId The QA package ID
+     */
+    suspend fun deleteByPackageId(packageId: QaPackageId)
+
+    /**
+     * Counts scenarios by QA package.
+     *
+     * @param packageId The QA package ID
+     * @return The count
+     */
+    suspend fun countByPackageId(packageId: QaPackageId): Long
+
+    /**
+     * Counts scenarios by status.
+     *
+     * @param status The status to count
+     * @return The count
+     */
+    suspend fun countByStatus(status: ScenarioStatus): Long
+
+    /**
+     * Counts all scenarios.
+     *
+     * @return The total count
+     */
+    suspend fun count(): Long
+}
+
+/**
+ * Command for creating a new test scenario.
+ */
+data class CreateScenarioCommand(
+    val qaPackageId: QaPackageId? = null,
+    val suiteId: TestSuiteId? = null,
+    val name: String,
+    val description: String? = null,
+    val steps: List<TestStep>,
+    val tags: Set<String> = emptySet(),
+    val source: ScenarioSource,
+    val status: ScenarioStatus = ScenarioStatus.PENDING
+) {
+    init {
+        require(name.isNotBlank()) { "Scenario name cannot be blank" }
+        require(steps.isNotEmpty()) { "Scenario must have at least one step" }
+        require(steps.map { it.index }.toSet().size == steps.size) { "Step indices must be unique" }
+    }
+}
+
+/**
+ * Command for updating a test scenario.
+ */
+data class UpdateScenarioCommand(
+    val name: String? = null,
+    val description: String? = null,
+    val steps: List<TestStep>? = null,
+    val tags: Set<String>? = null,
+    val status: ScenarioStatus? = null
+) {
+    init {
+        steps?.let {
+            require(it.isNotEmpty()) { "Scenario must have at least one step" }
+            require(it.map { step -> step.index }.toSet().size == it.size) { "Step indices must be unique" }
+        }
+    }
+}

--- a/src/main/kotlin/com/qawave/application/service/ScenarioServiceImpl.kt
+++ b/src/main/kotlin/com/qawave/application/service/ScenarioServiceImpl.kt
@@ -1,0 +1,233 @@
+package com.qawave.application.service
+
+import com.qawave.domain.model.*
+import com.qawave.infrastructure.persistence.mapper.TestScenarioMapper
+import com.qawave.infrastructure.persistence.repository.TestScenarioR2dbcRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+/**
+ * Implementation of ScenarioService using R2DBC repository.
+ */
+@Service
+@Transactional
+class ScenarioServiceImpl(
+    private val repository: TestScenarioR2dbcRepository,
+    private val mapper: TestScenarioMapper
+) : ScenarioService {
+
+    private val logger = LoggerFactory.getLogger(ScenarioServiceImpl::class.java)
+
+    override suspend fun create(command: CreateScenarioCommand): TestScenario {
+        logger.debug("Creating scenario: {}", command.name)
+
+        val now = Instant.now()
+        val scenario = TestScenario(
+            id = ScenarioId.generate(),
+            suiteId = command.suiteId,
+            qaPackageId = command.qaPackageId,
+            name = command.name,
+            description = command.description,
+            steps = command.steps,
+            tags = command.tags,
+            source = command.source,
+            status = command.status,
+            createdAt = now,
+            updatedAt = now
+        )
+
+        val entity = mapper.toEntityWithId(scenario, scenario.id.value)
+        val savedEntity = repository.save(entity)
+
+        logger.info("Created scenario: {} with id: {}", scenario.name, scenario.id.value)
+        return mapper.toDomain(savedEntity)
+    }
+
+    override suspend fun createBatch(commands: List<CreateScenarioCommand>): List<TestScenario> {
+        logger.debug("Creating {} scenarios in batch", commands.size)
+
+        val scenarios = commands.map { command ->
+            val now = Instant.now()
+            TestScenario(
+                id = ScenarioId.generate(),
+                suiteId = command.suiteId,
+                qaPackageId = command.qaPackageId,
+                name = command.name,
+                description = command.description,
+                steps = command.steps,
+                tags = command.tags,
+                source = command.source,
+                status = command.status,
+                createdAt = now,
+                updatedAt = now
+            )
+        }
+
+        val entities = scenarios.map { mapper.toEntityWithId(it, it.id.value) }
+        val savedEntities = repository.saveAll(entities).toList()
+
+        logger.info("Created {} scenarios in batch", savedEntities.size)
+        return savedEntities.map { mapper.toDomain(it) }
+    }
+
+    override suspend fun findById(id: ScenarioId): TestScenario? {
+        logger.debug("Finding scenario by id: {}", id.value)
+        return repository.findById(id.value)?.let { mapper.toDomain(it) }
+    }
+
+    override suspend fun findAll(page: Int, size: Int): Page<TestScenario> {
+        logger.debug("Finding all scenarios, page: {}, size: {}", page, size)
+
+        val offset = page * size
+        val entities = repository.findAll().toList()
+        val totalElements = entities.size.toLong()
+        val totalPages = if (size > 0) ((totalElements + size - 1) / size).toInt() else 0
+
+        val pagedEntities = entities
+            .drop(offset)
+            .take(size)
+            .map { mapper.toDomain(it) }
+
+        return Page(
+            content = pagedEntities,
+            page = page,
+            size = size,
+            totalElements = totalElements,
+            totalPages = totalPages
+        )
+    }
+
+    override fun findAllStream(): Flow<TestScenario> {
+        logger.debug("Streaming all scenarios")
+        return repository.findAll().map { mapper.toDomain(it) }
+    }
+
+    override suspend fun findByPackageId(packageId: QaPackageId): List<TestScenario> {
+        logger.debug("Finding scenarios by package id: {}", packageId.value)
+        return repository.findByQaPackageId(packageId.value).map { mapper.toDomain(it) }
+    }
+
+    override fun findByPackageIdStream(packageId: QaPackageId): Flow<TestScenario> {
+        logger.debug("Streaming scenarios by package id: {}", packageId.value)
+        return repository.findAllByQaPackageId(packageId.value).map { mapper.toDomain(it) }
+    }
+
+    override suspend fun findBySuiteId(suiteId: TestSuiteId): List<TestScenario> {
+        logger.debug("Finding scenarios by suite id: {}", suiteId.value)
+        return repository.findBySuiteId(suiteId.value).map { mapper.toDomain(it) }
+    }
+
+    override suspend fun findByStatus(status: ScenarioStatus): List<TestScenario> {
+        logger.debug("Finding scenarios by status: {}", status)
+        return repository.findByStatus(status.name).map { mapper.toDomain(it) }
+    }
+
+    override fun findByStatusStream(status: ScenarioStatus): Flow<TestScenario> {
+        logger.debug("Streaming scenarios by status: {}", status)
+        return repository.findAllByStatus(status.name).map { mapper.toDomain(it) }
+    }
+
+    override suspend fun findBySource(source: ScenarioSource): List<TestScenario> {
+        logger.debug("Finding scenarios by source: {}", source)
+        return repository.findBySource(source.name).map { mapper.toDomain(it) }
+    }
+
+    override fun findRecent(since: Instant): Flow<TestScenario> {
+        logger.debug("Finding scenarios created since: {}", since)
+        return repository.findRecentScenarios(since).map { mapper.toDomain(it) }
+    }
+
+    override fun findByTag(tag: String): Flow<TestScenario> {
+        logger.debug("Finding scenarios by tag: {}", tag)
+        return repository.findByTag("[\"$tag\"]").map { mapper.toDomain(it) }
+    }
+
+    override suspend fun update(id: ScenarioId, command: UpdateScenarioCommand): TestScenario {
+        logger.debug("Updating scenario: {}", id.value)
+
+        val existing = repository.findById(id.value)
+            ?: throw ScenarioNotFoundException(id)
+
+        val current = mapper.toDomain(existing)
+        val updated = TestScenario(
+            id = current.id,
+            suiteId = current.suiteId,
+            qaPackageId = current.qaPackageId,
+            name = command.name ?: current.name,
+            description = command.description ?: current.description,
+            steps = command.steps ?: current.steps,
+            tags = command.tags ?: current.tags,
+            source = current.source,
+            status = command.status ?: current.status,
+            createdAt = current.createdAt,
+            updatedAt = Instant.now()
+        )
+
+        val entity = mapper.toEntity(updated)
+        val savedEntity = repository.save(entity)
+
+        logger.info("Updated scenario: {}", id.value)
+        return mapper.toDomain(savedEntity)
+    }
+
+    override suspend fun updateStatus(id: ScenarioId, status: ScenarioStatus): TestScenario {
+        logger.debug("Updating scenario status: {} to {}", id.value, status)
+        return update(id, UpdateScenarioCommand(status = status))
+    }
+
+    override suspend fun markReady(id: ScenarioId): TestScenario {
+        return updateStatus(id, ScenarioStatus.READY)
+    }
+
+    override suspend fun markInvalid(id: ScenarioId): TestScenario {
+        return updateStatus(id, ScenarioStatus.INVALID)
+    }
+
+    override suspend fun disable(id: ScenarioId): TestScenario {
+        return updateStatus(id, ScenarioStatus.DISABLED)
+    }
+
+    override suspend fun enable(id: ScenarioId): TestScenario {
+        return updateStatus(id, ScenarioStatus.PENDING)
+    }
+
+    override suspend fun delete(id: ScenarioId): Boolean {
+        logger.debug("Deleting scenario: {}", id.value)
+
+        val exists = repository.existsById(id.value)
+        if (exists) {
+            repository.deleteById(id.value)
+            logger.info("Deleted scenario: {}", id.value)
+        }
+        return exists
+    }
+
+    override suspend fun deleteByPackageId(packageId: QaPackageId) {
+        logger.debug("Deleting scenarios for package: {}", packageId.value)
+        repository.deleteByQaPackageId(packageId.value)
+        logger.info("Deleted scenarios for package: {}", packageId.value)
+    }
+
+    override suspend fun countByPackageId(packageId: QaPackageId): Long {
+        return repository.countByQaPackageId(packageId.value)
+    }
+
+    override suspend fun countByStatus(status: ScenarioStatus): Long {
+        return repository.countByStatus(status.name)
+    }
+
+    override suspend fun count(): Long {
+        return repository.count()
+    }
+}
+
+/**
+ * Exception thrown when a scenario is not found.
+ */
+class ScenarioNotFoundException(id: ScenarioId) :
+    RuntimeException("Scenario not found: ${id.value}")

--- a/src/main/kotlin/com/qawave/infrastructure/persistence/mapper/TestScenarioMapper.kt
+++ b/src/main/kotlin/com/qawave/infrastructure/persistence/mapper/TestScenarioMapper.kt
@@ -1,0 +1,114 @@
+package com.qawave.infrastructure.persistence.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.qawave.domain.model.*
+import com.qawave.infrastructure.persistence.entity.TestScenarioEntity
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Mapper for converting between TestScenarioEntity and TestScenario domain model.
+ */
+@Component
+class TestScenarioMapper(
+    private val objectMapper: ObjectMapper
+) {
+
+    /**
+     * Converts an entity to a domain model.
+     */
+    fun toDomain(entity: TestScenarioEntity): TestScenario {
+        return TestScenario(
+            id = ScenarioId(entity.id!!),
+            suiteId = entity.suiteId?.let { TestSuiteId(it) },
+            qaPackageId = entity.qaPackageId?.let { QaPackageId(it) },
+            name = entity.name,
+            description = entity.description,
+            steps = parseSteps(entity.stepsJson),
+            tags = parseTags(entity.tags),
+            source = ScenarioSource.valueOf(entity.source),
+            status = ScenarioStatus.valueOf(entity.status),
+            createdAt = entity.createdAt,
+            updatedAt = entity.updatedAt
+        )
+    }
+
+    /**
+     * Converts a domain model to an entity.
+     */
+    fun toEntity(domain: TestScenario): TestScenarioEntity {
+        return TestScenarioEntity(
+            id = domain.id.value,
+            suiteId = domain.suiteId?.value,
+            qaPackageId = domain.qaPackageId?.value,
+            name = domain.name,
+            description = domain.description,
+            stepsJson = objectMapper.writeValueAsString(domain.steps),
+            tags = serializeTags(domain.tags),
+            source = domain.source.name,
+            status = domain.status.name,
+            createdAt = domain.createdAt,
+            updatedAt = domain.updatedAt
+        )
+    }
+
+    /**
+     * Creates a new entity from a domain model (for insert).
+     */
+    fun toNewEntity(domain: TestScenario): TestScenarioEntity {
+        return TestScenarioEntity(
+            id = null,
+            suiteId = domain.suiteId?.value,
+            qaPackageId = domain.qaPackageId?.value,
+            name = domain.name,
+            description = domain.description,
+            stepsJson = objectMapper.writeValueAsString(domain.steps),
+            tags = serializeTags(domain.tags),
+            source = domain.source.name,
+            status = domain.status.name,
+            createdAt = domain.createdAt,
+            updatedAt = domain.updatedAt
+        )
+    }
+
+    /**
+     * Creates an entity with a specified ID (for insert with predetermined ID).
+     */
+    fun toEntityWithId(domain: TestScenario, id: UUID): TestScenarioEntity {
+        return TestScenarioEntity(
+            id = id,
+            suiteId = domain.suiteId?.value,
+            qaPackageId = domain.qaPackageId?.value,
+            name = domain.name,
+            description = domain.description,
+            stepsJson = objectMapper.writeValueAsString(domain.steps),
+            tags = serializeTags(domain.tags),
+            source = domain.source.name,
+            status = domain.status.name,
+            createdAt = domain.createdAt,
+            updatedAt = Instant.now()
+        )
+    }
+
+    private fun parseSteps(json: String): List<TestStep> {
+        return try {
+            objectMapper.readValue(json)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    private fun parseTags(json: String?): Set<String> {
+        return try {
+            json?.let { objectMapper.readValue<Set<String>>(it) } ?: emptySet()
+        } catch (e: Exception) {
+            emptySet()
+        }
+    }
+
+    private fun serializeTags(tags: Set<String>): String? {
+        return if (tags.isEmpty()) null else objectMapper.writeValueAsString(tags)
+    }
+}

--- a/src/test/kotlin/com/qawave/unit/service/ScenarioServiceTest.kt
+++ b/src/test/kotlin/com/qawave/unit/service/ScenarioServiceTest.kt
@@ -1,0 +1,387 @@
+package com.qawave.unit.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.qawave.application.service.*
+import com.qawave.domain.model.*
+import com.qawave.infrastructure.persistence.entity.TestScenarioEntity
+import com.qawave.infrastructure.persistence.mapper.TestScenarioMapper
+import com.qawave.infrastructure.persistence.repository.TestScenarioR2dbcRepository
+import io.mockk.*
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ScenarioServiceTest {
+
+    @MockK
+    private lateinit var repository: TestScenarioR2dbcRepository
+
+    private lateinit var objectMapper: ObjectMapper
+    private lateinit var mapper: TestScenarioMapper
+    private lateinit var service: ScenarioServiceImpl
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        objectMapper = jacksonObjectMapper().findAndRegisterModules()
+        mapper = TestScenarioMapper(objectMapper)
+        service = ScenarioServiceImpl(repository, mapper)
+    }
+
+    @Nested
+    inner class CreateTests {
+        @Test
+        fun `create saves and returns scenario`() = runTest {
+            val command = createCommand()
+            val entitySlot = slot<TestScenarioEntity>()
+
+            coEvery { repository.save(capture(entitySlot)) } coAnswers {
+                entitySlot.captured.copy(id = entitySlot.captured.id ?: UUID.randomUUID())
+            }
+
+            val result = service.create(command)
+
+            assertNotNull(result)
+            assertEquals(command.name, result.name)
+            assertEquals(command.source, result.source)
+            assertEquals(command.steps.size, result.steps.size)
+
+            coVerify { repository.save(any()) }
+        }
+
+        @Test
+        fun `createBatch saves multiple scenarios`() = runTest {
+            val commands = listOf(
+                createCommand(name = "Scenario 1"),
+                createCommand(name = "Scenario 2")
+            )
+
+            coEvery { repository.saveAll(any<List<TestScenarioEntity>>()) } returns flowOf(
+                createEntity(name = "Scenario 1"),
+                createEntity(name = "Scenario 2")
+            )
+
+            val results = service.createBatch(commands)
+
+            assertEquals(2, results.size)
+            assertEquals("Scenario 1", results[0].name)
+            assertEquals("Scenario 2", results[1].name)
+        }
+    }
+
+    @Nested
+    inner class FindTests {
+        @Test
+        fun `findById returns scenario when found`() = runTest {
+            val id = UUID.randomUUID()
+            val entity = createEntity(id = id)
+
+            coEvery { repository.findById(id) } returns entity
+
+            val result = service.findById(ScenarioId(id))
+
+            assertNotNull(result)
+            assertEquals(id, result.id.value)
+        }
+
+        @Test
+        fun `findById returns null when not found`() = runTest {
+            val id = UUID.randomUUID()
+
+            coEvery { repository.findById(id) } returns null
+
+            val result = service.findById(ScenarioId(id))
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `findByPackageId returns scenarios for package`() = runTest {
+            val packageId = UUID.randomUUID()
+            val entities = listOf(
+                createEntity(qaPackageId = packageId),
+                createEntity(qaPackageId = packageId)
+            )
+
+            coEvery { repository.findByQaPackageId(packageId) } returns entities
+
+            val results = service.findByPackageId(QaPackageId(packageId))
+
+            assertEquals(2, results.size)
+        }
+
+        @Test
+        fun `findBySuiteId returns scenarios for suite`() = runTest {
+            val suiteId = UUID.randomUUID()
+            val entities = listOf(createEntity(suiteId = suiteId))
+
+            coEvery { repository.findBySuiteId(suiteId) } returns entities
+
+            val results = service.findBySuiteId(TestSuiteId(suiteId))
+
+            assertEquals(1, results.size)
+        }
+
+        @Test
+        fun `findByStatus returns scenarios with status`() = runTest {
+            val entities = listOf(createEntity(status = "READY"))
+
+            coEvery { repository.findByStatus("READY") } returns entities
+
+            val results = service.findByStatus(ScenarioStatus.READY)
+
+            assertEquals(1, results.size)
+            assertEquals(ScenarioStatus.READY, results[0].status)
+        }
+
+        @Test
+        fun `findByStatusStream returns flow of scenarios`() = runTest {
+            val entities = listOf(createEntity(status = "PENDING"))
+
+            every { repository.findAllByStatus("PENDING") } returns flowOf(*entities.toTypedArray())
+
+            val results = service.findByStatusStream(ScenarioStatus.PENDING).toList()
+
+            assertEquals(1, results.size)
+        }
+
+        @Test
+        fun `findBySource returns scenarios by source`() = runTest {
+            val entities = listOf(createEntity(source = "AI_GENERATED"))
+
+            coEvery { repository.findBySource("AI_GENERATED") } returns entities
+
+            val results = service.findBySource(ScenarioSource.AI_GENERATED)
+
+            assertEquals(1, results.size)
+        }
+    }
+
+    @Nested
+    inner class UpdateTests {
+        @Test
+        fun `update modifies scenario fields`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id, name = "Original")
+            val command = UpdateScenarioCommand(name = "Updated")
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.update(ScenarioId(id), command)
+
+            assertEquals("Updated", result.name)
+        }
+
+        @Test
+        fun `update throws when scenario not found`() = runTest {
+            val id = UUID.randomUUID()
+
+            coEvery { repository.findById(id) } returns null
+
+            assertThrows<ScenarioNotFoundException> {
+                service.update(ScenarioId(id), UpdateScenarioCommand(name = "Test"))
+            }
+        }
+
+        @Test
+        fun `updateStatus changes scenario status`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id, status = "PENDING")
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.updateStatus(ScenarioId(id), ScenarioStatus.READY)
+
+            assertEquals(ScenarioStatus.READY, result.status)
+        }
+
+        @Test
+        fun `markReady sets status to READY`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id, status = "PENDING")
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.markReady(ScenarioId(id))
+
+            assertEquals(ScenarioStatus.READY, result.status)
+        }
+
+        @Test
+        fun `markInvalid sets status to INVALID`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id)
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.markInvalid(ScenarioId(id))
+
+            assertEquals(ScenarioStatus.INVALID, result.status)
+        }
+
+        @Test
+        fun `disable sets status to DISABLED`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id)
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.disable(ScenarioId(id))
+
+            assertEquals(ScenarioStatus.DISABLED, result.status)
+        }
+
+        @Test
+        fun `enable sets status to PENDING`() = runTest {
+            val id = UUID.randomUUID()
+            val existing = createEntity(id = id, status = "DISABLED")
+
+            coEvery { repository.findById(id) } returns existing
+            coEvery { repository.save(any()) } coAnswers { firstArg() }
+
+            val result = service.enable(ScenarioId(id))
+
+            assertEquals(ScenarioStatus.PENDING, result.status)
+        }
+    }
+
+    @Nested
+    inner class DeleteTests {
+        @Test
+        fun `delete removes scenario when exists`() = runTest {
+            val id = UUID.randomUUID()
+
+            coEvery { repository.existsById(id) } returns true
+            coEvery { repository.deleteById(id) } just runs
+
+            val result = service.delete(ScenarioId(id))
+
+            assertTrue(result)
+            coVerify { repository.deleteById(id) }
+        }
+
+        @Test
+        fun `delete returns false when not exists`() = runTest {
+            val id = UUID.randomUUID()
+
+            coEvery { repository.existsById(id) } returns false
+
+            val result = service.delete(ScenarioId(id))
+
+            assertFalse(result)
+            coVerify(exactly = 0) { repository.deleteById(any()) }
+        }
+
+        @Test
+        fun `deleteByPackageId removes all scenarios for package`() = runTest {
+            val packageId = UUID.randomUUID()
+
+            coEvery { repository.deleteByQaPackageId(packageId) } just runs
+
+            service.deleteByPackageId(QaPackageId(packageId))
+
+            coVerify { repository.deleteByQaPackageId(packageId) }
+        }
+    }
+
+    @Nested
+    inner class CountTests {
+        @Test
+        fun `countByPackageId returns count`() = runTest {
+            val packageId = UUID.randomUUID()
+
+            coEvery { repository.countByQaPackageId(packageId) } returns 5
+
+            val result = service.countByPackageId(QaPackageId(packageId))
+
+            assertEquals(5, result)
+        }
+
+        @Test
+        fun `countByStatus returns count`() = runTest {
+            coEvery { repository.countByStatus("READY") } returns 10
+
+            val result = service.countByStatus(ScenarioStatus.READY)
+
+            assertEquals(10, result)
+        }
+
+        @Test
+        fun `count returns total count`() = runTest {
+            coEvery { repository.count() } returns 100
+
+            val result = service.count()
+
+            assertEquals(100, result)
+        }
+    }
+
+    private fun createCommand(
+        name: String = "Test Scenario",
+        packageId: QaPackageId? = null,
+        suiteId: TestSuiteId? = null
+    ) = CreateScenarioCommand(
+        qaPackageId = packageId,
+        suiteId = suiteId,
+        name = name,
+        description = "Test description",
+        steps = listOf(createStep()),
+        tags = setOf("test"),
+        source = ScenarioSource.MANUAL
+    )
+
+    private fun createStep(
+        index: Int = 0,
+        method: HttpMethod = HttpMethod.GET,
+        endpoint: String = "/api/test"
+    ) = TestStep(
+        index = index,
+        name = "Step $index",
+        method = method,
+        endpoint = endpoint,
+        expected = ExpectedResult(status = 200)
+    )
+
+    private fun createEntity(
+        id: UUID = UUID.randomUUID(),
+        name: String = "Test Scenario",
+        qaPackageId: UUID? = null,
+        suiteId: UUID? = null,
+        status: String = "PENDING",
+        source: String = "MANUAL"
+    ): TestScenarioEntity {
+        val steps = listOf(createStep())
+        return TestScenarioEntity(
+            id = id,
+            qaPackageId = qaPackageId,
+            suiteId = suiteId,
+            name = name,
+            description = "Test description",
+            stepsJson = objectMapper.writeValueAsString(steps),
+            tags = """["test"]""",
+            source = source,
+            status = status,
+            createdAt = Instant.now(),
+            updatedAt = Instant.now()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Implements ScenarioService interface for test scenario management
- Full CRUD operations with suspend functions
- Batch creation support for AI-generated scenarios
- Query by package, suite, status, source, and tag

## Changes
- `ScenarioService.kt`: Service interface with commands
- `ScenarioServiceImpl.kt`: Implementation using R2DBC repository
- `TestScenarioMapper.kt`: Entity/domain model conversion
- `ScenarioServiceTest.kt`: Comprehensive unit tests

## Test plan
- [x] Unit tests pass for all service methods
- [x] Build compiles successfully
- [x] All tests pass

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)