### PR TITLE
[DevOps] feat: deploy Keycloak to Kubernetes (#104)

### DIFF
--- a/infrastructure/argocd/applications/keycloak.yaml
+++ b/infrastructure/argocd/applications/keycloak.yaml
@@ -1,0 +1,89 @@
+# ArgoCD Application for Keycloak
+# Identity and Access Management Server
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qawave-keycloak
+  namespace: argocd
+  labels:
+    app: qawave
+    component: keycloak
+    environment: production
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"  # Deploy after data services
+spec:
+  project: qawave
+  source:
+    repoURL: https://charts.bitnami.com/bitnami
+    chart: keycloak
+    targetRevision: "24.*"
+    helm:
+      valueFiles:
+        - values.yaml
+      # Override values inline if needed
+      parameters:
+        - name: auth.existingSecret
+          value: keycloak-secrets
+        - name: externalDatabase.existingSecret
+          value: keycloak-db-secrets
+        - name: externalDatabase.existingSecretPasswordKey
+          value: password
+      # Additional values from repository
+      fileParameters:
+        - name: values.yaml
+          path: infrastructure/kubernetes/base/auth/keycloak/values.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: qawave
+  syncPolicy:
+    automated:
+      prune: false  # Don't auto-delete identity provider
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      jsonPointers:
+        - /data
+  revisionHistoryLimit: 5
+---
+# Alternative: Deploy Keycloak from repository values
+# Use this if ArgoCD cannot directly access Helm chart with repo values
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qawave-keycloak-config
+  namespace: argocd
+  labels:
+    app: qawave
+    component: keycloak-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"  # Deploy config first
+spec:
+  project: qawave
+  source:
+    repoURL: https://github.com/hermanngeorge15/qawave-automation.git
+    targetRevision: main
+    path: infrastructure/kubernetes/base/auth/keycloak
+    directory:
+      recurse: false
+      exclude: "values.yaml|README.md|secrets.yaml*"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: qawave
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infrastructure/kubernetes/base/auth/keycloak/.gitignore
+++ b/infrastructure/kubernetes/base/auth/keycloak/.gitignore
@@ -1,0 +1,15 @@
+# Ignore actual secrets (use secrets.yaml.example as template)
+# DO NOT ignore secrets.yaml.example - it's the template
+/secrets.yaml
+!/secrets.yaml.example
+
+# Ignore sealed secrets if stored locally
+/sealed-secrets.yaml
+
+# Ignore local state files
+*.tfstate
+*.tfstate.backup
+
+# Ignore editor backups
+*~
+*.swp

--- a/infrastructure/kubernetes/base/auth/keycloak/README.md
+++ b/infrastructure/kubernetes/base/auth/keycloak/README.md
@@ -1,0 +1,234 @@
+# Keycloak Deployment for QAWave
+
+This directory contains the Kubernetes deployment configuration for Keycloak, the identity and access management server for QAWave.
+
+## Overview
+
+Keycloak provides:
+- User authentication and authorization
+- OAuth 2.0 / OpenID Connect endpoints
+- User federation and identity brokering
+- Admin console for user management
+- Role-based access control (RBAC)
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Frontend      │────▶│    Keycloak     │────▶│   PostgreSQL    │
+│   (PKCE Auth)   │     │   (auth.qawave) │     │   (keycloak db) │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+        │                       │
+        │                       │
+        ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐
+│    Backend      │────▶│  Token          │
+│ (JWT Validate)  │     │  Introspection  │
+└─────────────────┘     └─────────────────┘
+```
+
+## Prerequisites
+
+1. **Kubernetes cluster** with ingress controller (nginx-ingress)
+2. **PostgreSQL** deployed and accessible
+3. **Helm 3.x** installed
+4. **cert-manager** for TLS certificates (optional but recommended)
+
+## Installation
+
+### Step 1: Add Bitnami Helm Repository
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+```
+
+### Step 2: Create Namespace (if not exists)
+
+```bash
+kubectl create namespace qawave
+```
+
+### Step 3: Initialize Keycloak Database
+
+Apply the database initialization ConfigMap and run the init script:
+
+```bash
+# Apply ConfigMap
+kubectl apply -f init-db-configmap.yaml
+
+# Execute init script on PostgreSQL
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -f /tmp/init-keycloak.sql
+
+# Or manually create database:
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -c "CREATE USER keycloak WITH PASSWORD 'your-password';"
+kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -c "CREATE DATABASE keycloak OWNER keycloak;"
+```
+
+### Step 4: Create Secrets
+
+```bash
+# Copy example and customize
+cp secrets.yaml.example secrets.yaml
+# Edit secrets.yaml with actual passwords
+
+# Apply secrets
+kubectl apply -f secrets.yaml
+
+# For production, use Sealed Secrets:
+kubeseal --format yaml < secrets.yaml > sealed-secrets.yaml
+kubectl apply -f sealed-secrets.yaml
+```
+
+### Step 5: Deploy Keycloak
+
+```bash
+# Using Helm directly
+helm install keycloak bitnami/keycloak \
+  --namespace qawave \
+  --values values.yaml \
+  --set auth.existingSecret=keycloak-secrets \
+  --set externalDatabase.existingSecret=keycloak-db-secrets
+
+# Or using ArgoCD (recommended)
+kubectl apply -f ../../argocd/applications/keycloak.yaml
+```
+
+### Step 6: Verify Deployment
+
+```bash
+# Check pods
+kubectl get pods -n qawave -l app.kubernetes.io/name=keycloak
+
+# Check service
+kubectl get svc -n qawave -l app.kubernetes.io/name=keycloak
+
+# Check ingress
+kubectl get ingress -n qawave -l app.kubernetes.io/name=keycloak
+
+# View logs
+kubectl logs -n qawave -l app.kubernetes.io/name=keycloak -f
+```
+
+## Configuration
+
+### Environment Variables
+
+Key environment variables configured in `values.yaml`:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `KC_HEALTH_ENABLED` | Enable health endpoints | `true` |
+| `KC_METRICS_ENABLED` | Enable Prometheus metrics | `true` |
+| `KC_HOSTNAME_STRICT` | Strict hostname validation | `false` |
+| `KC_CACHE` | Cache mode (local/ispn) | `local` |
+
+### Database Configuration
+
+Keycloak uses an external PostgreSQL database:
+- Host: `postgresql.qawave.svc.cluster.local`
+- Port: `5432`
+- Database: `keycloak`
+- User: `keycloak`
+
+### TLS Configuration
+
+TLS is terminated at the ingress controller. For end-to-end TLS:
+
+1. Enable cert-manager cluster issuer
+2. Configure ingress TLS settings in `values.yaml`
+
+## Accessing Keycloak
+
+### Admin Console
+
+- URL: `https://auth.qawave.local/admin`
+- Default admin: Configured in secrets
+
+### Account Console
+
+- URL: `https://auth.qawave.local/realms/{realm}/account`
+
+### OpenID Configuration
+
+- URL: `https://auth.qawave.local/realms/{realm}/.well-known/openid-configuration`
+
+## Monitoring
+
+### Health Endpoints
+
+- Liveness: `http://keycloak:8080/health/live`
+- Readiness: `http://keycloak:8080/health/ready`
+- Started: `http://keycloak:8080/health/started`
+
+### Metrics
+
+Prometheus metrics available at: `http://keycloak:8080/metrics`
+
+## Backup and Recovery
+
+### Export Realm Configuration
+
+```bash
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kc.sh export \
+  --dir /tmp/export \
+  --realm qawave
+```
+
+### Import Realm Configuration
+
+```bash
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kc.sh import \
+  --dir /tmp/import
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pod stuck in CrashLoopBackOff**
+   - Check database connectivity
+   - Verify secrets are correct
+   - Check resource limits
+
+2. **Cannot access admin console**
+   - Verify ingress configuration
+   - Check TLS certificates
+   - Ensure proxy headers are configured
+
+3. **Database connection errors**
+   - Verify PostgreSQL is running
+   - Check network policies
+   - Validate connection credentials
+
+### Useful Commands
+
+```bash
+# Get pod logs
+kubectl logs -n qawave -l app.kubernetes.io/name=keycloak --tail=100
+
+# Describe pod
+kubectl describe pod -n qawave -l app.kubernetes.io/name=keycloak
+
+# Check events
+kubectl get events -n qawave --sort-by=.metadata.creationTimestamp
+
+# Port forward for local access
+kubectl port-forward svc/keycloak -n qawave 8080:80
+```
+
+## Security Considerations
+
+1. **Admin credentials**: Use strong passwords, rotate regularly
+2. **Network policies**: Restrict access to Keycloak pods
+3. **TLS**: Always use HTTPS in production
+4. **Secrets**: Use Sealed Secrets or external secret management
+5. **Updates**: Keep Keycloak updated for security patches
+
+## Related Documentation
+
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Bitnami Keycloak Chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak)
+- [OAuth 2.0 / OIDC](https://oauth.net/2/)

--- a/infrastructure/kubernetes/base/auth/keycloak/init-db-configmap.yaml
+++ b/infrastructure/kubernetes/base/auth/keycloak/init-db-configmap.yaml
@@ -1,0 +1,40 @@
+# ConfigMap for Keycloak database initialization
+# This SQL script creates the keycloak database and user in PostgreSQL
+#
+# Run this before deploying Keycloak:
+#   kubectl exec -it postgresql-0 -n qawave -- psql -U postgres -f /tmp/init-keycloak.sql
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-init-db
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: database-init
+data:
+  init-keycloak.sql: |
+    -- Create keycloak database and user
+    -- Run as postgres superuser
+
+    -- Create user if not exists
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'keycloak') THEN
+        CREATE USER keycloak WITH PASSWORD 'REPLACE_WITH_ACTUAL_PASSWORD';
+      END IF;
+    END
+    $$;
+
+    -- Create database if not exists
+    SELECT 'CREATE DATABASE keycloak OWNER keycloak'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'keycloak')\gexec
+
+    -- Grant privileges
+    GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;
+
+    -- Connect to keycloak database and set up permissions
+    \c keycloak
+    GRANT ALL ON SCHEMA public TO keycloak;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO keycloak;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO keycloak;

--- a/infrastructure/kubernetes/base/auth/keycloak/kustomization.yaml
+++ b/infrastructure/kubernetes/base/auth/keycloak/kustomization.yaml
@@ -1,0 +1,32 @@
+# Kustomization for Keycloak
+# This file is used by ArgoCD to manage Keycloak deployment
+#
+# Note: Keycloak is deployed using Helm, so this kustomization
+# primarily manages additional resources like secrets and configs
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qawave
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: qawave
+    includeSelectors: false
+
+resources:
+  # Add secrets.yaml here once created (or sealed-secrets.yaml)
+  # - secrets.yaml
+  - init-db-configmap.yaml
+
+# Common labels for all resources
+commonLabels:
+  environment: production
+
+# Patches for environment-specific configuration
+# patches:
+#   - path: patches/production-values.yaml
+#     target:
+#       kind: HelmRelease
+#       name: keycloak

--- a/infrastructure/kubernetes/base/auth/keycloak/secrets.yaml.example
+++ b/infrastructure/kubernetes/base/auth/keycloak/secrets.yaml.example
@@ -1,0 +1,36 @@
+# Keycloak Secrets Example
+# Copy this file to secrets.yaml and update with actual values
+# DO NOT commit secrets.yaml to version control
+#
+# For production, use Sealed Secrets:
+#   kubeseal --format yaml < secrets.yaml > sealed-secrets.yaml
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-secrets
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: identity-provider
+type: Opaque
+stringData:
+  # Keycloak admin credentials
+  admin-user: admin
+  admin-password: CHANGE_ME_STRONG_PASSWORD
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-secrets
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: database
+type: Opaque
+stringData:
+  # PostgreSQL credentials for Keycloak database
+  username: keycloak
+  password: CHANGE_ME_DB_PASSWORD
+  # Connection URL (alternative to individual fields)
+  # jdbc-url: jdbc:postgresql://postgresql.qawave.svc.cluster.local:5432/keycloak

--- a/infrastructure/kubernetes/base/auth/keycloak/values.yaml
+++ b/infrastructure/kubernetes/base/auth/keycloak/values.yaml
@@ -1,0 +1,209 @@
+# Keycloak Helm Values for QAWave
+# Chart: bitnami/keycloak
+# Version: 24.x
+#
+# Install:
+#   helm repo add bitnami https://charts.bitnami.com/bitnami
+#   helm install keycloak bitnami/keycloak -n qawave -f values.yaml
+#
+
+# Keycloak version
+image:
+  tag: "24.0.4"
+
+# Authentication configuration
+auth:
+  adminUser: admin
+  # Admin password should be overridden via --set or secrets
+  # existingSecret: keycloak-secrets
+  # passwordSecretKey: admin-password
+
+# Production mode
+production: true
+
+# Proxy configuration for running behind load balancer
+proxy: edge
+
+# HTTP/HTTPS configuration
+httpRelativePath: "/"
+
+# Logging configuration
+logging:
+  level: INFO
+
+# PostgreSQL database configuration
+postgresql:
+  enabled: false  # Use external PostgreSQL
+
+externalDatabase:
+  host: postgresql.qawave.svc.cluster.local
+  port: 5432
+  database: keycloak
+  user: keycloak
+  # Password should be overridden via --set or secrets
+  # existingSecret: keycloak-db-secrets
+  # existingSecretPasswordKey: password
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    http: 80
+    https: 443
+
+# Ingress configuration
+ingress:
+  enabled: true
+  ingressClassName: nginx
+  hostname: auth.qawave.local
+  path: /
+  pathType: Prefix
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+  tls: true
+  # extraTls:
+  #   - hosts:
+  #       - auth.qawave.local
+  #     secretName: keycloak-tls
+
+# Resource limits
+resources:
+  requests:
+    cpu: 500m
+    memory: 1Gi
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+
+# Replica count (for HA in production)
+replicaCount: 1
+
+# Pod disruption budget
+pdb:
+  create: true
+  minAvailable: 1
+
+# Liveness and readiness probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+# Startup probe for slow startup scenarios
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 60
+  successThreshold: 1
+
+# Extra environment variables for Keycloak configuration
+extraEnvVars:
+  - name: KC_HEALTH_ENABLED
+    value: "true"
+  - name: KC_METRICS_ENABLED
+    value: "true"
+  - name: KC_HOSTNAME_STRICT
+    value: "false"
+  - name: KC_HOSTNAME_STRICT_HTTPS
+    value: "false"
+  # Cache configuration for clustering
+  - name: KC_CACHE
+    value: "local"  # Change to "ispn" for clustered setup
+  # Theme configuration
+  - name: KC_SPI_THEME_DEFAULT
+    value: "keycloak"
+
+# Pod annotations for monitoring
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/metrics"
+
+# Pod labels
+podLabels:
+  app.kubernetes.io/component: identity-provider
+
+# Affinity rules
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: keycloak
+          topologyKey: kubernetes.io/hostname
+
+# Service account
+serviceAccount:
+  create: true
+  name: keycloak
+
+# Network policy
+networkPolicy:
+  enabled: true
+  allowExternal: true
+  additionalRules:
+    - ports:
+        - port: 8080
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+    - ports:
+        - port: 8080
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: qawave
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+    - ports:
+        - port: 8080
+          protocol: TCP
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: qawave
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: frontend
+
+# Metrics for Prometheus
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: false  # Enable if using Prometheus Operator
+    interval: 30s
+
+# Init containers for database readiness check
+initContainers:
+  - name: wait-for-postgresql
+    image: busybox:1.36
+    command:
+      - sh
+      - -c
+      - |
+        until nc -z postgresql.qawave.svc.cluster.local 5432; do
+          echo "Waiting for PostgreSQL..."
+          sleep 2
+        done
+        echo "PostgreSQL is ready"


### PR DESCRIPTION
## Summary
- Add Keycloak identity and access management deployment configuration
- Use Bitnami Keycloak Helm chart (v24.x)
- Configure PostgreSQL database integration
- Set up TLS-enabled ingress at auth.qawave.local
- Add ArgoCD application for GitOps deployment

## Changes
- `infrastructure/kubernetes/base/auth/keycloak/` - Keycloak K8s manifests
  - `values.yaml` - Helm chart values
  - `secrets.yaml.example` - Secrets template
  - `init-db-configmap.yaml` - Database initialization script
  - `kustomization.yaml` - Kustomize configuration
  - `README.md` - Comprehensive documentation
- `infrastructure/argocd/applications/keycloak.yaml` - ArgoCD application

## Acceptance Criteria
- [x] Keycloak Helm chart configured
- [x] PostgreSQL database for Keycloak state
- [x] Ingress configured for Keycloak admin console
- [x] TLS enabled for Keycloak endpoints
- [x] Health checks configured
- [x] Resource limits set appropriately
- [x] Documentation complete

## Test plan
- [ ] Deploy to staging cluster
- [ ] Verify Keycloak admin console accessible
- [ ] Verify database connectivity
- [ ] Verify health endpoints respond

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)