### PR TITLE
[DevOps] feat: configure Keycloak realm and clients (#105)

### DIFF
--- a/infrastructure/kubernetes/base/auth/keycloak/realm/README.md
+++ b/infrastructure/kubernetes/base/auth/keycloak/realm/README.md
@@ -1,0 +1,267 @@
+# QAWave Keycloak Realm Configuration
+
+This directory contains the Keycloak realm configuration for QAWave authentication and authorization.
+
+## Overview
+
+The `qawave` realm provides:
+- OAuth 2.0 / OpenID Connect authentication
+- Role-based access control (RBAC)
+- Client configurations for frontend and backend
+- User management
+
+## Realm Structure
+
+```
+qawave (realm)
+├── Clients
+│   ├── qawave-backend   (confidential, service account)
+│   └── qawave-frontend  (public, PKCE)
+├── Roles
+│   ├── admin    → Can manage everything
+│   ├── tester   → Can create/run tests
+│   └── viewer   → Read-only access
+└── Users
+    ├── admin@qawave.local   (admin role)
+    ├── tester@qawave.local  (tester role)
+    └── viewer@qawave.local  (viewer role)
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `qawave-realm.json` | Full realm export for import |
+| `test-users.json` | Test users for development |
+| `realm-configmap.yaml` | K8s ConfigMap for realm import |
+
+## Client Configuration
+
+### qawave-backend (Confidential Client)
+
+For backend service-to-service authentication:
+
+| Setting | Value |
+|---------|-------|
+| Client ID | `qawave-backend` |
+| Client Protocol | OpenID Connect |
+| Access Type | Confidential |
+| Service Accounts | Enabled |
+| Standard Flow | Disabled |
+| Direct Access Grants | Disabled |
+
+**Use cases:**
+- Token introspection
+- Service-to-service calls
+- Background job authentication
+
+### qawave-frontend (Public Client)
+
+For SPA frontend authentication:
+
+| Setting | Value |
+|---------|-------|
+| Client ID | `qawave-frontend` |
+| Client Protocol | OpenID Connect |
+| Access Type | Public |
+| PKCE | Required (S256) |
+| Standard Flow | Enabled |
+
+**Redirect URIs:**
+- `http://localhost:3000/*` (dev)
+- `http://localhost:5173/*` (vite dev)
+- `https://qawave.local/*` (staging)
+- `https://app.qawave.local/*` (production)
+
+## Roles
+
+### Hierarchy
+
+```
+admin
+  └── tester
+        └── viewer
+```
+
+### Permissions
+
+| Role | Packages | Scenarios | Runs | Users |
+|------|----------|-----------|------|-------|
+| admin | CRUD | CRUD | CRUD | CRUD |
+| tester | CRU | CRUD | CRU | - |
+| viewer | R | R | R | - |
+
+## Token Configuration
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| Access Token Lifespan | 5 min | Short-lived for security |
+| Refresh Token Lifespan | 30 min | SSO session timeout |
+| SSO Session Max | 10 hours | Maximum session length |
+| Offline Session | 30 days | Remember me duration |
+
+## Importing the Realm
+
+### Method 1: Keycloak Admin Console
+
+1. Log into Keycloak Admin Console
+2. Select "Create realm"
+3. Click "Import"
+4. Upload `qawave-realm.json`
+
+### Method 2: CLI Import
+
+```bash
+# Using kcadm.sh inside container
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kcadm.sh config credentials \
+  --server http://localhost:8080 \
+  --realm master \
+  --user admin \
+  --password $KEYCLOAK_ADMIN_PASSWORD
+
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kcadm.sh create realms \
+  -f /opt/bitnami/keycloak/data/import/qawave-realm.json
+```
+
+### Method 3: Startup Import
+
+Configure Keycloak to import on startup:
+
+```yaml
+# In values.yaml
+extraEnvVars:
+  - name: KEYCLOAK_EXTRA_ARGS
+    value: "--import-realm"
+
+extraVolumes:
+  - name: realm-config
+    secret:
+      secretName: keycloak-realm-import
+
+extraVolumeMounts:
+  - name: realm-config
+    mountPath: /opt/bitnami/keycloak/data/import
+    readOnly: true
+```
+
+## Adding Test Users
+
+### Via Admin Console
+
+1. Go to Users > Add user
+2. Fill in user details
+3. Go to Credentials tab
+4. Set password
+5. Go to Role Mappings
+6. Assign appropriate role
+
+### Via CLI
+
+```bash
+# Create user
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kcadm.sh create users \
+  -r qawave \
+  -s username=newuser \
+  -s email=newuser@example.com \
+  -s enabled=true
+
+# Set password
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kcadm.sh set-password \
+  -r qawave \
+  --username newuser \
+  --new-password "SecurePassword123!"
+
+# Assign role
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kcadm.sh add-roles \
+  -r qawave \
+  --uusername newuser \
+  --rolename tester
+```
+
+## Exporting Realm Configuration
+
+To export the current realm configuration for version control:
+
+```bash
+# Export realm without users
+kubectl exec -it keycloak-0 -n qawave -- \
+  /opt/bitnami/keycloak/bin/kc.sh export \
+  --dir /tmp/export \
+  --realm qawave \
+  --users skip
+
+# Copy export to local
+kubectl cp qawave/keycloak-0:/tmp/export/qawave-realm.json ./qawave-realm.json
+```
+
+## Integration with Applications
+
+### Backend (Kotlin/Spring)
+
+```yaml
+# application.yml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://auth.qawave.local/realms/qawave
+          jwk-set-uri: https://auth.qawave.local/realms/qawave/protocol/openid-connect/certs
+
+keycloak:
+  realm: qawave
+  auth-server-url: https://auth.qawave.local
+  resource: qawave-backend
+  credentials:
+    secret: ${KEYCLOAK_CLIENT_SECRET}
+```
+
+### Frontend (React)
+
+```typescript
+// keycloak.ts
+import Keycloak from 'keycloak-js';
+
+const keycloak = new Keycloak({
+  url: 'https://auth.qawave.local',
+  realm: 'qawave',
+  clientId: 'qawave-frontend',
+});
+
+export default keycloak;
+```
+
+## Security Considerations
+
+1. **Client Secrets**: Store in Kubernetes Secrets, rotate regularly
+2. **Token Lifetime**: Keep access tokens short-lived (5 min)
+3. **PKCE**: Always use PKCE for public clients
+4. **Redirect URIs**: Whitelist specific URLs only
+5. **Password Policy**: Enforce strong passwords
+6. **Brute Force**: Protection enabled (5 failures = lockout)
+
+## Troubleshooting
+
+### Token Validation Fails
+
+1. Check clock synchronization between services
+2. Verify issuer URI matches Keycloak configuration
+3. Check if token is expired
+4. Verify JWKS endpoint is accessible
+
+### CORS Issues
+
+Ensure web origins are configured in the client:
+- Include all frontend URLs
+- Include localhost for development
+
+### Login Redirect Loop
+
+1. Check redirect URI configuration
+2. Verify cookies are not being blocked
+3. Check browser console for errors

--- a/infrastructure/kubernetes/base/auth/keycloak/realm/qawave-realm.json
+++ b/infrastructure/kubernetes/base/auth/keycloak/realm/qawave-realm.json
@@ -1,0 +1,315 @@
+{
+  "id": "qawave",
+  "realm": "qawave",
+  "displayName": "QAWave",
+  "displayNameHtml": "<div class=\"kc-logo-text\"><span>QAWave</span></div>",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 5,
+  "defaultRole": {
+    "id": "qawave-default-roles",
+    "name": "default-roles-qawave",
+    "description": "Default roles for QAWave realm",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "qawave"
+  },
+  "roles": {
+    "realm": [
+      {
+        "id": "admin",
+        "name": "admin",
+        "description": "Full administrative access to QAWave",
+        "composite": true,
+        "composites": {
+          "realm": ["tester", "viewer"]
+        },
+        "clientRole": false,
+        "containerId": "qawave",
+        "attributes": {}
+      },
+      {
+        "id": "tester",
+        "name": "tester",
+        "description": "Can create and run tests, view results",
+        "composite": true,
+        "composites": {
+          "realm": ["viewer"]
+        },
+        "clientRole": false,
+        "containerId": "qawave",
+        "attributes": {}
+      },
+      {
+        "id": "viewer",
+        "name": "viewer",
+        "description": "Read-only access to test results and reports",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "qawave",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "qawave-backend": [
+        {
+          "id": "service-account",
+          "name": "service-account",
+          "description": "Service account role for backend",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "qawave-backend"
+        }
+      ],
+      "qawave-frontend": []
+    }
+  },
+  "clients": [
+    {
+      "id": "qawave-backend",
+      "clientId": "qawave-backend",
+      "name": "QAWave Backend API",
+      "description": "Backend API service client (confidential)",
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "REPLACE_WITH_BACKEND_SECRET",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "access.token.lifespan": "300",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "qawave-frontend",
+      "clientId": "qawave-frontend",
+      "name": "QAWave Frontend Application",
+      "description": "Frontend SPA client (public, PKCE)",
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:3000/*",
+        "http://localhost:5173/*",
+        "https://qawave.local/*",
+        "https://app.qawave.local/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://qawave.local",
+        "https://app.qawave.local"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "access.token.lifespan": "300",
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:3000/*##http://localhost:5173/*##https://qawave.local/*##https://app.qawave.local/*",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "qawave-api",
+      "name": "qawave-api",
+      "description": "QAWave API scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "Access to QAWave API"
+      },
+      "protocolMappers": [
+        {
+          "id": "qawave-roles-mapper",
+          "name": "qawave-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "roles",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "keycloak",
+  "accountTheme": "keycloak.v2",
+  "adminTheme": "keycloak.v2",
+  "emailTheme": "keycloak",
+  "eventsEnabled": true,
+  "eventsExpiration": 604800,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR",
+    "REGISTER",
+    "REGISTER_ERROR",
+    "CODE_TO_TOKEN",
+    "CODE_TO_TOKEN_ERROR",
+    "CLIENT_LOGIN",
+    "CLIENT_LOGIN_ERROR",
+    "REFRESH_TOKEN",
+    "REFRESH_TOKEN_ERROR",
+    "REVOKE_GRANT",
+    "REVOKE_GRANT_ERROR",
+    "UPDATE_EMAIL",
+    "UPDATE_PROFILE",
+    "UPDATE_PASSWORD",
+    "UPDATE_TOTP",
+    "VERIFY_EMAIL",
+    "REMOVE_TOTP",
+    "SEND_RESET_PASSWORD",
+    "RESET_PASSWORD",
+    "RESET_PASSWORD_ERROR",
+    "IMPERSONATE",
+    "CUSTOM_REQUIRED_ACTION"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
+  "internationalizationEnabled": true,
+  "supportedLocales": [
+    "en",
+    "cs"
+  ],
+  "defaultLocale": "en",
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "passwordPolicy": "length(8) and digits(1) and upperCase(1) and specialChars(1) and notUsername",
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName",
+    "totpAppFreeOTPName"
+  ]
+}

--- a/infrastructure/kubernetes/base/auth/keycloak/realm/realm-configmap.yaml
+++ b/infrastructure/kubernetes/base/auth/keycloak/realm/realm-configmap.yaml
@@ -1,0 +1,62 @@
+# ConfigMap for Keycloak Realm Import
+# This ConfigMap contains the QAWave realm configuration
+# Mount this as a volume in Keycloak pod for realm import
+#
+# Usage:
+#   kubectl apply -f realm-configmap.yaml
+#   Then update Keycloak deployment to mount this ConfigMap
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm-config
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: realm-config
+data:
+  # Realm import flags
+  KEYCLOAK_EXTRA_ARGS: "--import-realm"
+
+  # Note: The actual realm JSON should be mounted from a Secret for production
+  # This ConfigMap is for the import configuration only
+
+  # Import configuration
+  import-config.yaml: |
+    # Keycloak import configuration
+    # Place realm JSON files in /opt/bitnami/keycloak/data/import/
+    #
+    # Supported import strategies:
+    # - IGNORE_EXISTING: Skip if realm exists
+    # - OVERWRITE_EXISTING: Update existing realm
+    # - FAIL: Fail if realm exists
+    #
+    import:
+      strategy: IGNORE_EXISTING
+      dir: /opt/bitnami/keycloak/data/import
+---
+# Secret for realm JSON (production)
+# Create from realm JSON file:
+#   kubectl create secret generic keycloak-realm-import \
+#     --from-file=qawave-realm.json=realm/qawave-realm.json \
+#     -n qawave
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-realm-import
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: realm-import
+type: Opaque
+stringData:
+  # Note: In production, replace REPLACE_WITH_* placeholders
+  # and use kubeseal to create a SealedSecret
+  qawave-realm.json: |
+    {
+      "realm": "qawave",
+      "enabled": true,
+      "displayName": "QAWave",
+      "note": "Full realm config should be imported from qawave-realm.json"
+    }

--- a/infrastructure/kubernetes/base/auth/keycloak/realm/test-users.json
+++ b/infrastructure/kubernetes/base/auth/keycloak/realm/test-users.json
@@ -1,0 +1,64 @@
+{
+  "users": [
+    {
+      "id": "admin-user",
+      "username": "admin@qawave.local",
+      "email": "admin@qawave.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "REPLACE_WITH_ADMIN_PASSWORD",
+          "temporary": true
+        }
+      ],
+      "realmRoles": ["admin"],
+      "attributes": {
+        "department": ["Engineering"]
+      }
+    },
+    {
+      "id": "tester-user",
+      "username": "tester@qawave.local",
+      "email": "tester@qawave.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "Test",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "REPLACE_WITH_TESTER_PASSWORD",
+          "temporary": true
+        }
+      ],
+      "realmRoles": ["tester"],
+      "attributes": {
+        "department": ["QA"]
+      }
+    },
+    {
+      "id": "viewer-user",
+      "username": "viewer@qawave.local",
+      "email": "viewer@qawave.local",
+      "emailVerified": true,
+      "enabled": true,
+      "firstName": "View",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "REPLACE_WITH_VIEWER_PASSWORD",
+          "temporary": true
+        }
+      ],
+      "realmRoles": ["viewer"],
+      "attributes": {
+        "department": ["Stakeholder"]
+      }
+    }
+  ]
+}

--- a/infrastructure/kubernetes/base/auth/keycloak/realm/values-realm-import.yaml
+++ b/infrastructure/kubernetes/base/auth/keycloak/realm/values-realm-import.yaml
@@ -1,0 +1,25 @@
+# Keycloak Values Patch for Realm Import
+# Apply this patch on top of the base values.yaml to enable realm import
+#
+# Usage with Helm:
+#   helm upgrade keycloak bitnami/keycloak \
+#     -n qawave \
+#     -f values.yaml \
+#     -f realm/values-realm-import.yaml
+#
+
+# Extra environment variables for realm import
+extraEnvVars:
+  - name: KEYCLOAK_EXTRA_ARGS
+    value: "--import-realm"
+
+# Mount realm configuration
+extraVolumes:
+  - name: realm-config
+    secret:
+      secretName: keycloak-realm-import
+
+extraVolumeMounts:
+  - name: realm-config
+    mountPath: /opt/bitnami/keycloak/data/import
+    readOnly: true


### PR DESCRIPTION
## Summary
Configure Keycloak realm for QAWave application including clients for backend and frontend.

**Depends on: #113** (Deploy Keycloak to Kubernetes)

## Changes

### Realm Configuration (`qawave`)
- OAuth 2.0 / OpenID Connect protocol
- Brute force protection (5 failures = lockout)
- Password policy (length, digits, uppercase, special chars)
- Event logging enabled
- Internationalization (EN, CS)

### Clients

| Client | Type | Auth Flow | Use Case |
|--------|------|-----------|----------|
| `qawave-backend` | Confidential | Service Account | Backend API, token introspection |
| `qawave-frontend` | Public | Authorization Code + PKCE | SPA authentication |

### Roles (Hierarchical)
```
admin (full access)
  └── tester (create/run tests)
        └── viewer (read-only)
```

### Token Configuration
- Access Token: 5 minutes
- Refresh Token: 30 minutes
- SSO Session: 10 hours
- Offline Session: 30 days

## Files Added
- `realm/qawave-realm.json` - Full realm export for import
- `realm/test-users.json` - Test users for development
- `realm/realm-configmap.yaml` - K8s ConfigMap for import
- `realm/values-realm-import.yaml` - Helm values patch
- `realm/README.md` - Documentation

## Acceptance Criteria
- [x] Create 'qawave' realm
- [x] Configure 'qawave-backend' client (confidential, service account)
- [x] Configure 'qawave-frontend' client (public, PKCE)
- [x] Define roles: admin, tester, viewer
- [x] Configure token settings
- [x] Create test users for each role
- [x] Export realm configuration for version control
- [x] Documentation complete

## Test plan
- [ ] Import realm via Admin Console
- [ ] Verify clients appear in realm
- [ ] Verify roles are created
- [ ] Test user login with each role
- [ ] Verify PKCE flow works for frontend
- [ ] Verify service account flow works for backend

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)