### PR TITLE
[Frontend] feat: implement ScenariosPage (#98)

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -12,7 +12,7 @@ export {
 
 // API Modules
 export { default as packagesApi, packagesApi as packages } from './packages'
-export { default as scenariosApi, scenariosApi as scenarios } from './scenarios'
+export { default as scenariosApi, scenariosApi as scenarios, type ScenariosListParams } from './scenarios'
 export { default as runsApi, runsApi as runs } from './runs'
 
 // Types

--- a/frontend/src/api/scenarios.ts
+++ b/frontend/src/api/scenarios.ts
@@ -3,7 +3,33 @@ import type { Scenario, PaginatedResponse } from './types'
 
 const BASE_PATH = '/api/qa/scenarios'
 
+export interface ScenariosListParams {
+  page?: number | undefined
+  size?: number | undefined
+  packageId?: string | undefined
+  status?: string | undefined
+  search?: string | undefined
+}
+
 export const scenariosApi = {
+  /**
+   * List all scenarios with optional filters
+   */
+  list(params: ScenariosListParams = {}, signal?: AbortSignal): Promise<PaginatedResponse<Scenario>> {
+    const searchParams = new URLSearchParams()
+    if (params.page !== undefined) searchParams.set('page', String(params.page))
+    if (params.size !== undefined) searchParams.set('size', String(params.size))
+    if (params.packageId) searchParams.set('packageId', params.packageId)
+    if (params.status) searchParams.set('status', params.status)
+    if (params.search) searchParams.set('search', params.search)
+
+    const queryString = searchParams.toString()
+    return apiClient.get<PaginatedResponse<Scenario>>(
+      `${BASE_PATH}${queryString ? `?${queryString}` : ''}`,
+      { signal }
+    )
+  },
+
   /**
    * List scenarios for a package
    */

--- a/frontend/src/hooks/useScenarios.ts
+++ b/frontend/src/hooks/useScenarios.ts
@@ -1,11 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { scenariosApi } from '@/api'
+import { scenariosApi, type ScenariosListParams } from '@/api/scenarios'
 import { packageKeys } from './usePackages'
 
 // Query key factory
 export const scenarioKeys = {
   all: ['scenarios'] as const,
   lists: () => [...scenarioKeys.all, 'list'] as const,
+  list: (params: ScenariosListParams) => [...scenarioKeys.lists(), params] as const,
   listByPackage: (packageId: string, page: number, size: number) =>
     [...scenarioKeys.lists(), { packageId, page, size }] as const,
   details: () => [...scenarioKeys.all, 'detail'] as const,
@@ -13,6 +14,13 @@ export const scenarioKeys = {
 }
 
 // Hooks
+export function useScenarios(params: ScenariosListParams = {}) {
+  return useQuery({
+    queryKey: scenarioKeys.list(params),
+    queryFn: ({ signal }) => scenariosApi.list(params, signal),
+  })
+}
+
 export function usePackageScenarios(packageId: string, page = 0, size = 20) {
   return useQuery({
     queryKey: scenarioKeys.listByPackage(packageId, page, size),

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AppRouteImport } from './routes/_app'
 import { Route as AppIndexRouteImport } from './routes/_app/index'
 import { Route as AppSettingsRouteImport } from './routes/_app/settings'
+import { Route as AppScenariosRouteImport } from './routes/_app/scenarios'
 import { Route as AppPackagesRouteImport } from './routes/_app/packages'
 import { Route as AppRunsRunIdRouteImport } from './routes/_app/runs.$runId'
 import { Route as AppPackagesNewRouteImport } from './routes/_app/packages.new'
@@ -29,6 +30,11 @@ const AppIndexRoute = AppIndexRouteImport.update({
 const AppSettingsRoute = AppSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppScenariosRoute = AppScenariosRouteImport.update({
+  id: '/scenarios',
+  path: '/scenarios',
   getParentRoute: () => AppRoute,
 } as any)
 const AppPackagesRoute = AppPackagesRouteImport.update({
@@ -55,6 +61,7 @@ const AppPackagesPackageIdRoute = AppPackagesPackageIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof AppIndexRoute
   '/packages': typeof AppPackagesRouteWithChildren
+  '/scenarios': typeof AppScenariosRoute
   '/settings': typeof AppSettingsRoute
   '/packages/$packageId': typeof AppPackagesPackageIdRoute
   '/packages/new': typeof AppPackagesNewRoute
@@ -62,6 +69,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/packages': typeof AppPackagesRouteWithChildren
+  '/scenarios': typeof AppScenariosRoute
   '/settings': typeof AppSettingsRoute
   '/': typeof AppIndexRoute
   '/packages/$packageId': typeof AppPackagesPackageIdRoute
@@ -72,6 +80,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_app': typeof AppRouteWithChildren
   '/_app/packages': typeof AppPackagesRouteWithChildren
+  '/_app/scenarios': typeof AppScenariosRoute
   '/_app/settings': typeof AppSettingsRoute
   '/_app/': typeof AppIndexRoute
   '/_app/packages/$packageId': typeof AppPackagesPackageIdRoute
@@ -83,6 +92,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/packages'
+    | '/scenarios'
     | '/settings'
     | '/packages/$packageId'
     | '/packages/new'
@@ -90,6 +100,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/packages'
+    | '/scenarios'
     | '/settings'
     | '/'
     | '/packages/$packageId'
@@ -99,6 +110,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_app'
     | '/_app/packages'
+    | '/_app/scenarios'
     | '/_app/settings'
     | '/_app/'
     | '/_app/packages/$packageId'
@@ -131,6 +143,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof AppSettingsRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/_app/scenarios': {
+      id: '/_app/scenarios'
+      path: '/scenarios'
+      fullPath: '/scenarios'
+      preLoaderRoute: typeof AppScenariosRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/packages': {
@@ -180,6 +199,7 @@ const AppPackagesRouteWithChildren = AppPackagesRoute._addFileChildren(
 
 interface AppRouteChildren {
   AppPackagesRoute: typeof AppPackagesRouteWithChildren
+  AppScenariosRoute: typeof AppScenariosRoute
   AppSettingsRoute: typeof AppSettingsRoute
   AppIndexRoute: typeof AppIndexRoute
   AppRunsRunIdRoute: typeof AppRunsRunIdRoute
@@ -187,6 +207,7 @@ interface AppRouteChildren {
 
 const AppRouteChildren: AppRouteChildren = {
   AppPackagesRoute: AppPackagesRouteWithChildren,
+  AppScenariosRoute: AppScenariosRoute,
   AppSettingsRoute: AppSettingsRoute,
   AppIndexRoute: AppIndexRoute,
   AppRunsRunIdRoute: AppRunsRunIdRoute,

--- a/frontend/src/routes/_app/scenarios.tsx
+++ b/frontend/src/routes/_app/scenarios.tsx
@@ -1,0 +1,275 @@
+import { useState, useMemo } from 'react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useScenarios, usePackages } from '@/hooks'
+import { StatusBadge, EmptyState, Skeleton } from '@/components/ui'
+import type { Scenario, ScenarioStatus } from '@/api/types'
+
+export const Route = createFileRoute('/_app/scenarios')({
+  component: ScenariosPage,
+})
+
+function ScenariosListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="card flex items-center gap-4">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-6 w-20 rounded-full" />
+          <div className="ml-auto">
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface ScenarioRowProps {
+  scenario: Scenario
+  packageName: string | undefined
+}
+
+function ScenarioRow({ scenario, packageName }: ScenarioRowProps) {
+  return (
+    <div className="card hover:border-primary-500 transition-colors">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-white truncate">{scenario.name}</h3>
+          {scenario.description && (
+            <p className="text-secondary-400 text-sm line-clamp-1 mt-1">{scenario.description}</p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          <div className="flex items-center gap-2 text-secondary-400">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+              />
+            </svg>
+            <span className="truncate max-w-[120px]" title={packageName}>
+              {packageName ?? 'Unknown Package'}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2 text-secondary-400">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+              />
+            </svg>
+            <span>{scenario.steps.length} steps</span>
+          </div>
+
+          <StatusBadge status={scenario.status} />
+        </div>
+
+        <Link
+          to="/packages/$packageId"
+          params={{ packageId: scenario.packageId }}
+          className="btn btn-ghost text-sm py-1 px-3 shrink-0"
+        >
+          View Package
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+const STATUS_OPTIONS: { value: ScenarioStatus | ''; label: string }[] = [
+  { value: '', label: 'All Statuses' },
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'RUNNING', label: 'Running' },
+  { value: 'PASSED', label: 'Passed' },
+  { value: 'FAILED', label: 'Failed' },
+  { value: 'SKIPPED', label: 'Skipped' },
+]
+
+function ScenariosPage() {
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState('')
+  const [selectedPackage, setSelectedPackage] = useState('')
+  const [selectedStatus, setSelectedStatus] = useState<ScenarioStatus | ''>('')
+  const pageSize = 20
+
+  // Fetch packages for the filter dropdown
+  const { data: packagesData } = usePackages(0, 100)
+
+  // Fetch scenarios with filters
+  const { data, isLoading, isError, error } = useScenarios({
+    page,
+    size: pageSize,
+    packageId: selectedPackage || undefined,
+    status: selectedStatus || undefined,
+    search: search || undefined,
+  })
+
+  // Create a map of package IDs to names for display
+  const packageNameMap = useMemo(() => {
+    const map = new Map<string, string>()
+    packagesData?.content.forEach((pkg) => {
+      map.set(pkg.id, pkg.name)
+    })
+    return map
+  }, [packagesData])
+
+  // Reset to first page when filters change
+  const handleSearchChange = (value: string) => {
+    setSearch(value)
+    setPage(0)
+  }
+
+  const handlePackageChange = (value: string) => {
+    setSelectedPackage(value)
+    setPage(0)
+  }
+
+  const handleStatusChange = (value: string) => {
+    setSelectedStatus(value as ScenarioStatus | '')
+    setPage(0)
+  }
+
+  const scenarios = data?.content ?? []
+
+  return (
+    <div className="scenarios-page">
+      <header className="mb-8">
+        <h1 className="page-title">Test Scenarios</h1>
+        <p className="text-secondary-400">View and manage test scenarios across all packages</p>
+      </header>
+
+      {/* Filters */}
+      <div className="flex flex-col sm:flex-row gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Search scenarios..."
+          value={search}
+          onChange={(e) => {
+            handleSearchChange(e.target.value)
+          }}
+          className="w-full sm:w-80 px-4 py-2 bg-secondary-800 border border-secondary-700 rounded-lg text-white placeholder-secondary-500 focus:outline-none focus:border-primary-500 transition-colors"
+        />
+
+        <select
+          value={selectedPackage}
+          onChange={(e) => {
+            handlePackageChange(e.target.value)
+          }}
+          className="px-4 py-2 bg-secondary-800 border border-secondary-700 rounded-lg text-white focus:outline-none focus:border-primary-500 transition-colors"
+        >
+          <option value="">All Packages</option>
+          {packagesData?.content.map((pkg) => (
+            <option key={pkg.id} value={pkg.id}>
+              {pkg.name}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={selectedStatus}
+          onChange={(e) => {
+            handleStatusChange(e.target.value)
+          }}
+          className="px-4 py-2 bg-secondary-800 border border-secondary-700 rounded-lg text-white focus:outline-none focus:border-primary-500 transition-colors"
+        >
+          {STATUS_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <ScenariosListSkeleton />
+      ) : isError ? (
+        <div className="error-state">
+          <h2>Error loading scenarios</h2>
+          <p>{error.message}</p>
+          <button
+            onClick={() => {
+              window.location.reload()
+            }}
+            className="btn btn-primary mt-4"
+          >
+            Retry
+          </button>
+        </div>
+      ) : scenarios.length === 0 ? (
+        <EmptyState
+          title={search || selectedPackage || selectedStatus ? 'No scenarios found' : 'No scenarios yet'}
+          description={
+            search || selectedPackage || selectedStatus
+              ? 'Try adjusting your filters'
+              : 'Scenarios will appear here after generating them from a QA package'
+          }
+          action={
+            !(search || selectedPackage || selectedStatus) && (
+              <Link to="/packages" className="btn btn-primary">
+                View Packages
+              </Link>
+            )
+          }
+          icon={
+            <svg className="w-full h-full" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+              />
+            </svg>
+          }
+        />
+      ) : (
+        <>
+          <div className="space-y-3">
+            {scenarios.map((scenario) => (
+              <ScenarioRow
+                key={scenario.id}
+                scenario={scenario}
+                packageName={packageNameMap.get(scenario.packageId)}
+              />
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {data && data.totalPages > 1 && (
+            <div className="flex justify-center items-center gap-4 mt-8">
+              <button
+                onClick={() => {
+                  setPage((p) => Math.max(0, p - 1))
+                }}
+                disabled={data.first}
+                className="btn btn-ghost disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span className="text-secondary-400">
+                Page {page + 1} of {data.totalPages}
+              </span>
+              <button
+                onClick={() => {
+                  setPage((p) => p + 1)
+                }}
+                disabled={data.last}
+                className="btn btn-ghost disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Implement ScenariosPage to list and manage test scenarios across all packages
- Add scenarios API endpoint for listing all scenarios with filters
- Add useScenarios hook for querying scenarios

## Features
- Display scenarios in a list view with name, package, step count, and status
- Filter by package (dropdown)
- Filter by status (dropdown)
- Search by scenario name
- Pagination for large datasets
- Empty state when no scenarios exist
- Loading skeleton during data fetch
- Link to parent package from each scenario

## Test plan
- [ ] Navigate to /scenarios and verify page loads
- [ ] Verify scenarios are displayed with correct information
- [ ] Test search functionality
- [ ] Test package filter dropdown
- [ ] Test status filter dropdown
- [ ] Verify pagination works correctly
- [ ] Verify empty state displays when no scenarios
- [ ] Click "View Package" link and verify navigation

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)