### PR TITLE
[Backend] fix: align V014 status constraint with QaPackageStatus enum

### DIFF
--- a/backend/src/main/resources/db/migration/V014__change_status_to_varchar.sql
+++ b/backend/src/main/resources/db/migration/V014__change_status_to_varchar.sql
@@ -43,10 +43,16 @@ ALTER COLUMN mode TYPE VARCHAR(50) USING mode::text;
 ALTER TABLE qa_packages
 ALTER COLUMN mode SET DEFAULT 'STANDARD';
 
--- Add constraints for valid values
+-- Add constraints for valid values (matching QaPackageStatus enum in QaPackage.kt)
 ALTER TABLE qa_packages
 ADD CONSTRAINT chk_qa_packages_status_valid
-CHECK (status IN ('REQUESTED', 'SPEC_FETCHED', 'GENERATING', 'READY', 'EXECUTING', 'EVALUATING', 'COMPLETED', 'FAILED', 'CANCELLED'));
+CHECK (status IN (
+    'REQUESTED', 'SPEC_FETCHED', 'AI_SUCCESS',
+    'EXECUTION_IN_PROGRESS', 'EXECUTION_COMPLETE',
+    'QA_EVAL_IN_PROGRESS', 'QA_EVAL_DONE', 'COMPLETE',
+    'FAILED_SPEC_FETCH', 'FAILED_GENERATION', 'FAILED_EXECUTION',
+    'CANCELLED'
+));
 
 ALTER TABLE qa_packages
 ADD CONSTRAINT chk_qa_packages_mode_valid
@@ -56,15 +62,15 @@ CHECK (mode IN ('STANDARD', 'SECURITY', 'PERFORMANCE'));
 CREATE INDEX idx_qa_packages_status ON qa_packages(status);
 CREATE INDEX idx_qa_packages_mode ON qa_packages(mode);
 
--- Recreate partial indexes (now with varchar comparison)
+-- Recreate partial indexes (now with varchar comparison, matching actual enum values)
 CREATE INDEX idx_qa_packages_pending ON qa_packages(created_at)
-WHERE status IN ('REQUESTED', 'SPEC_FETCHED', 'GENERATING');
+WHERE status IN ('REQUESTED', 'SPEC_FETCHED', 'AI_SUCCESS');
 
 CREATE INDEX idx_qa_packages_running ON qa_packages(started_at)
-WHERE status IN ('EXECUTING', 'EVALUATING');
+WHERE status IN ('EXECUTION_IN_PROGRESS', 'QA_EVAL_IN_PROGRESS');
 
-CREATE INDEX idx_qa_packages_completed ON qa_packages(finished_at DESC)
-WHERE status = 'COMPLETED';
+CREATE INDEX idx_qa_packages_completed ON qa_packages(completed_at DESC)
+WHERE status = 'COMPLETE';
 
 CREATE INDEX idx_qa_packages_failed ON qa_packages(created_at DESC)
-WHERE status = 'FAILED';
+WHERE status IN ('FAILED_SPEC_FETCH', 'FAILED_GENERATION', 'FAILED_EXECUTION');


### PR DESCRIPTION
## Summary
Fix the V014 migration's CHECK constraint to match the actual `QaPackageStatus` enum values in the codebase.

## Problem
The status CHECK constraint in V014 was using incorrect enum values:
- Migration had: `GENERATING`, `READY`, `EXECUTING`, `EVALUATING`, `COMPLETED`, `FAILED`
- Code uses: `AI_SUCCESS`, `EXECUTION_IN_PROGRESS`, `EXECUTION_COMPLETE`, `QA_EVAL_IN_PROGRESS`, `QA_EVAL_DONE`, `COMPLETE`, `FAILED_SPEC_FETCH`, `FAILED_GENERATION`, `FAILED_EXECUTION`

## Changes
- Updated CHECK constraint with all correct enum values from `QaPackageStatus`
- Fixed partial indexes to use correct status values
- Changed `finished_at` to `completed_at` in completed index (matching entity field)

## Test plan
- [x] All 189 backend tests pass
- [x] Migration syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)