### PR TITLE
[Frontend] fix: resolve infinite re-render loop in CreatePackageModal (#124)

### DIFF
--- a/frontend/src/components/packages/CreatePackageModal.tsx
+++ b/frontend/src/components/packages/CreatePackageModal.tsx
@@ -32,14 +32,15 @@ export function CreatePackageModal({ isOpen, onClose }: CreatePackageModalProps)
   const resetForm = useCallback(() => {
     setFormData(initialFormData)
     setErrors({})
-    createPackage.reset()
-  }, [createPackage])
+  }, [])
 
   // Reset form when modal closes
   useEffect(() => {
     if (!isOpen) {
       resetForm()
+      createPackage.reset()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- createPackage.reset is stable, but object reference changes
   }, [isOpen, resetForm])
 
   const updateField = (field: keyof FormData, value: string) => {


### PR DESCRIPTION
## Summary

- Fix infinite re-render loop caused by TanStack Query mutation object reference changing on every render
- Move `createPackage.reset()` from `useCallback` to `useEffect` 
- Remove unstable dependency from resetForm callback

## Root Cause

The `createPackage` object from `useCreatePackage()` hook returns a new object reference on each render. Including it in the `useCallback` dependency array caused:

1. `resetForm` to be recreated every render
2. `useEffect` depending on `resetForm` to run
3. `resetForm()` calling state updates, triggering re-render
4. Infinite loop

## Changes

- `frontend/src/components/packages/CreatePackageModal.tsx`

## Test plan

- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm run test`)
- [ ] Manual test: open CreatePackageModal, verify no console warnings about "Maximum update depth exceeded"

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)