### PR TITLE
[Database] feat: ensure status constraint consistency across environments (#127)

### DIFF
--- a/backend/src/main/resources/db/migration/V016__ensure_status_constraint_consistency.sql
+++ b/backend/src/main/resources/db/migration/V016__ensure_status_constraint_consistency.sql
@@ -1,0 +1,74 @@
+-- V016__ensure_status_constraint_consistency.sql
+-- Description: Ensure qa_packages status constraint is consistent across all environments
+-- Author: Database Agent
+-- Date: 2026-01-26
+-- Issue: #127 - V014 was modified after deployment; this ensures consistency
+--
+-- Background:
+-- V014 was modified in PR #122 after being merged, causing potential checksum issues.
+-- Some environments may have run the old V014 (incorrect constraints) while others
+-- have the new V014 (correct constraints). This migration ensures all environments
+-- end up with the correct constraint values matching the QaPackageStatus enum.
+--
+-- This migration is idempotent - safe to run regardless of which V014 was applied.
+
+-- ============================================================================
+-- PART 1: Ensure status constraint matches QaPackageStatus enum
+-- ============================================================================
+
+-- Drop existing constraint if present (idempotent)
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'chk_qa_packages_status_valid' AND conrelid = 'qa_packages'::regclass) THEN
+        ALTER TABLE qa_packages DROP CONSTRAINT chk_qa_packages_status_valid;
+    END IF;
+END $$;
+
+-- Add constraint with correct values matching QaPackageStatus enum
+-- Source: backend/src/main/kotlin/com/qawave/domain/model/QaPackage.kt
+ALTER TABLE qa_packages
+ADD CONSTRAINT chk_qa_packages_status_valid
+CHECK (status IN (
+    'REQUESTED',
+    'SPEC_FETCHED',
+    'AI_SUCCESS',
+    'EXECUTION_IN_PROGRESS',
+    'EXECUTION_COMPLETE',
+    'QA_EVAL_IN_PROGRESS',
+    'QA_EVAL_DONE',
+    'COMPLETE',
+    'FAILED_SPEC_FETCH',
+    'FAILED_GENERATION',
+    'FAILED_EXECUTION',
+    'CANCELLED'
+));
+
+-- ============================================================================
+-- PART 2: Recreate partial indexes with correct status values
+-- ============================================================================
+
+-- Drop existing partial indexes (idempotent)
+DROP INDEX IF EXISTS idx_qa_packages_pending;
+DROP INDEX IF EXISTS idx_qa_packages_running;
+DROP INDEX IF EXISTS idx_qa_packages_completed;
+DROP INDEX IF EXISTS idx_qa_packages_failed;
+
+-- Recreate with correct values matching actual enum
+CREATE INDEX idx_qa_packages_pending ON qa_packages(created_at)
+WHERE status IN ('REQUESTED', 'SPEC_FETCHED', 'AI_SUCCESS');
+
+CREATE INDEX idx_qa_packages_running ON qa_packages(started_at)
+WHERE status IN ('EXECUTION_IN_PROGRESS', 'QA_EVAL_IN_PROGRESS');
+
+CREATE INDEX idx_qa_packages_completed ON qa_packages(completed_at DESC)
+WHERE status = 'COMPLETE';
+
+CREATE INDEX idx_qa_packages_failed ON qa_packages(created_at DESC)
+WHERE status IN ('FAILED_SPEC_FETCH', 'FAILED_GENERATION', 'FAILED_EXECUTION');
+
+-- ============================================================================
+-- PART 3: Documentation
+-- ============================================================================
+
+COMMENT ON CONSTRAINT chk_qa_packages_status_valid ON qa_packages IS
+    'Status values matching QaPackageStatus enum. Updated in V016 to ensure consistency after V014 modification incident.';


### PR DESCRIPTION
## Summary
- Add V016 migration to ensure all environments have consistent status constraint values
- Fixes inconsistency caused by V014 modification in PR #122 (post-merge)
- Migration is idempotent - safe to run regardless of which V014 was previously applied

## Changes
- New migration `V016__ensure_status_constraint_consistency.sql`:
  - Drops and recreates `chk_qa_packages_status_valid` constraint with correct enum values
  - Recreates partial indexes with correct status values
  - Fully documented with background context

## Why This Is Needed
After V014 was modified in PR #122 (despite warnings), environments could be in three states:
1. **Old V014** - wrong constraint values, checksum mismatch
2. **Old V014 + repair** - checksum fixed, but still wrong constraint values
3. **New V014** - correct values

V016 normalizes all environments to the correct state.

## Test Plan
- [x] Migration is syntactically valid SQL
- [ ] CI passes
- [ ] Apply to staging and verify constraint values

## Related
- Fixes #127
- Caused by PR #122

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)