### PR TITLE
[DevOps] feat: add CI/CD pipeline for staging deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,196 @@
+name: Build and Deploy to Staging
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'infrastructure/kubernetes/**'
+      - 'gitops/**'
+  workflow_dispatch:
+    inputs:
+      deploy_backend:
+        description: 'Deploy backend'
+        type: boolean
+        default: true
+      deploy_frontend:
+        description: 'Deploy frontend'
+        type: boolean
+        default: true
+
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository_owner }}/qawave-backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository_owner }}/qawave-frontend
+
+jobs:
+  # Detect what changed
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+
+  # Build Backend
+  build-backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || github.event.inputs.deploy_backend == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.BACKEND_IMAGE }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Build Frontend
+  build-frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event.inputs.deploy_frontend == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.FRONTEND_IMAGE }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # Deploy to Staging
+  deploy:
+    needs: [build-backend, build-frontend]
+    if: always() && (needs.build-backend.result == 'success' || needs.build-frontend.result == 'success')
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.29.0'
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_STAGING }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Verify cluster connection
+        run: kubectl get nodes
+
+      - name: Update backend image tag
+        if: needs.build-backend.result == 'success'
+        run: |
+          kubectl set image deployment/backend \
+            backend=${{ env.BACKEND_IMAGE }}:${{ github.sha }} \
+            -n staging --record || echo "Backend deployment not found, will be created by ArgoCD"
+
+      - name: Update frontend image tag
+        if: needs.build-frontend.result == 'success'
+        run: |
+          kubectl set image deployment/frontend \
+            frontend=${{ env.FRONTEND_IMAGE }}:${{ github.sha }} \
+            -n staging --record || echo "Frontend deployment not found, will be created by ArgoCD"
+
+      - name: Trigger ArgoCD sync
+        run: |
+          # Refresh ArgoCD applications
+          kubectl patch application staging-backend -n argocd \
+            --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' || true
+          kubectl patch application staging-frontend -n argocd \
+            --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' || true
+
+      - name: Wait for rollout
+        run: |
+          echo "Waiting for backend rollout..."
+          kubectl rollout status deployment/backend -n staging --timeout=300s || true
+          echo "Waiting for frontend rollout..."
+          kubectl rollout status deployment/frontend -n staging --timeout=300s || true
+
+      - name: Deployment summary
+        run: |
+          echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pods" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          kubectl get pods -n staging >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Services" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          kubectl get svc -n staging >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/gitops/envs/staging/apps.yaml
+++ b/gitops/envs/staging/apps.yaml
@@ -44,6 +44,48 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: staging-backend
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hermanngeorge15/qawave-automation.git
+    targetRevision: main
+    path: gitops/envs/staging/backend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: staging-frontend
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/hermanngeorge15/qawave-automation.git
+    targetRevision: main
+    path: gitops/envs/staging/frontend
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: staging
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: staging-kafka
   namespace: argocd
 spec:

--- a/gitops/envs/staging/backend/backend.yaml
+++ b/gitops/envs/staging/backend/backend.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-secrets
+  namespace: staging
+type: Opaque
+stringData:
+  SPRING_R2DBC_USERNAME: qawave
+  SPRING_R2DBC_PASSWORD: qawave-staging-app-2024
+  SPRING_DATA_REDIS_PASSWORD: qawave-staging-redis-2024
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: staging
+  labels:
+    app: qawave
+    component: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qawave
+      component: backend
+  template:
+    metadata:
+      labels:
+        app: qawave
+        component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/actuator/prometheus"
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/hermanngeorge15/qawave-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "staging"
+            - name: SPRING_R2DBC_URL
+              value: "r2dbc:postgresql://postgresql.staging.svc.cluster.local:5432/qawave"
+            - name: SPRING_R2DBC_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: SPRING_R2DBC_USERNAME
+            - name: SPRING_R2DBC_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: SPRING_R2DBC_PASSWORD
+            - name: SPRING_DATA_REDIS_HOST
+              value: "redis.staging.svc.cluster.local"
+            - name: SPRING_DATA_REDIS_PORT
+              value: "6379"
+            - name: SPRING_DATA_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secrets
+                  key: SPRING_DATA_REDIS_PASSWORD
+            - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
+              value: "kafka.staging.svc.cluster.local:9092"
+            - name: SERVER_PORT
+              value: "8080"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "250m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  namespace: staging
+  labels:
+    app: qawave
+    component: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: qawave
+    component: backend

--- a/gitops/envs/staging/frontend/frontend.yaml
+++ b/gitops/envs/staging/frontend/frontend.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: staging
+  labels:
+    app: qawave
+    component: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qawave
+      component: frontend
+  template:
+    metadata:
+      labels:
+        app: qawave
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/hermanngeorge15/qawave-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: staging
+  labels:
+    app: qawave
+    component: frontend
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      nodePort: 30000
+      protocol: TCP
+      name: http
+  selector:
+    app: qawave
+    component: frontend

--- a/infrastructure/kubernetes/base/backend/deployment.yaml
+++ b/infrastructure/kubernetes/base/backend/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: backend
-          image: ghcr.io/your-org/qawave/backend:latest
+          image: ghcr.io/hermanngeorge15/qawave-backend:latest
           imagePullPolicy: Always
           ports:
             - name: http

--- a/infrastructure/kubernetes/base/frontend/deployment.yaml
+++ b/infrastructure/kubernetes/base/frontend/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: qawave
+    component: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: qawave
+      component: frontend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: qawave
+        component: frontend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+      containers:
+        - name: frontend
+          image: ghcr.io/hermanngeorge15/qawave-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: API_URL
+              value: "http://backend.staging.svc.cluster.local:8080"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: qawave
+    component: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: qawave
+    component: frontend
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend
+  labels:
+    app: qawave
+    component: frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70


### PR DESCRIPTION
## Summary

This PR adds a complete CI/CD pipeline for deploying the QAWave backend and frontend to the Hetzner VPS staging environment.

### Changes

- **GitHub Actions Workflow** (`.github/workflows/build-and-deploy.yml`)
  - Builds Docker images for backend and frontend
  - Pushes images to GitHub Container Registry (GHCR)
  - Deploys to Hetzner VPS via kubectl
  - Triggers ArgoCD sync for GitOps

- **Frontend Kubernetes Manifests**
  - `infrastructure/kubernetes/base/frontend/deployment.yaml` - Base deployment
  - `gitops/envs/staging/frontend/frontend.yaml` - Staging-specific config

- **Backend GitOps Manifests**
  - `gitops/envs/staging/backend/backend.yaml` - Deployment with secrets

- **ArgoCD Applications**
  - Added `staging-backend` and `staging-frontend` applications

### Deployment Flow

```
Push to main
    ↓
GitHub Actions builds Docker images
    ↓
Images pushed to ghcr.io/hermanngeorge15/qawave-*
    ↓
kubectl updates image tags
    ↓
ArgoCD syncs changes
    ↓
Apps deployed to Hetzner VPS
```

### Access Points (after deployment)

| Service | URL |
|---------|-----|
| Frontend | http://46.224.232.46:30000 |
| Backend API | http://backend.staging:8080 (internal) |
| ArgoCD | http://91.99.107.246:30080 |

### Required GitHub Secrets

Before merging, add these secrets in GitHub Settings → Secrets → Actions:

| Secret | Description |
|--------|-------------|
| `KUBECONFIG_STAGING` | Base64 encoded kubeconfig for staging cluster |

To generate:
```bash
cat infrastructure/terraform/environments/staging/kubeconfig | base64
```

### E2E Tests

E2E tests are run separately on the Hetzner VPS cluster using:
```bash
./scripts/run-e2e-tests.sh
```

Results are viewed via kubectl logs.

## Test plan

- [ ] Verify GitHub Actions workflow syntax is valid
- [ ] Add `KUBECONFIG_STAGING` secret to GitHub
- [ ] Trigger manual workflow run
- [ ] Verify images are built and pushed to GHCR
- [ ] Verify deployments appear in ArgoCD
- [ ] Access frontend at NodePort 30000
- [ ] Run E2E tests locally

🤖 Generated with [Claude Code](https://claude.ai/code)