### PR TITLE
[DevOps] feat: set up Prometheus monitoring stack

### DIFF
--- a/infrastructure/argocd/applications/monitoring.yaml
+++ b/infrastructure/argocd/applications/monitoring.yaml
@@ -1,0 +1,356 @@
+# ArgoCD Application for Monitoring Stack
+# Deploys kube-prometheus-stack with ServiceMonitors for QAWave
+#
+# Components:
+#   - Prometheus: Metrics collection and storage
+#   - Alertmanager: Alert routing and notification
+#   - Grafana: Visualization dashboards
+#   - Node Exporter: Host metrics
+#   - kube-state-metrics: Kubernetes state metrics
+#
+# Prerequisites:
+#   1. monitoring namespace must exist
+#   2. Storage class available for persistent volumes
+
+---
+# AppProject for monitoring (separate from application workloads)
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: monitoring
+  namespace: argocd
+spec:
+  description: Monitoring and Observability Stack
+  sourceRepos:
+    - 'https://prometheus-community.github.io/helm-charts'
+    - 'https://github.com/hermanngeorge15/qawave-automation.git'
+  destinations:
+    - namespace: monitoring
+      server: https://kubernetes.default.svc
+    - namespace: qawave
+      server: https://kubernetes.default.svc
+  clusterResourceWhitelist:
+    - group: ''
+      kind: Namespace
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRole
+    - group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+  namespaceResourceWhitelist:
+    - group: ''
+      kind: '*'
+    - group: apps
+      kind: '*'
+    - group: monitoring.coreos.com
+      kind: '*'
+    - group: networking.k8s.io
+      kind: '*'
+
+---
+# Deploy kube-prometheus-stack using Helm
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  labels:
+    app: monitoring
+    component: prometheus
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: monitoring
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: kube-prometheus-stack
+    targetRevision: "67.*"
+    helm:
+      releaseName: kube-prometheus-stack
+      valuesObject:
+        # Global settings
+        global:
+          rbac:
+            create: true
+            pspEnabled: false
+
+        # Prometheus configuration
+        prometheus:
+          enabled: true
+          prometheusSpec:
+            # Retention configuration
+            retention: 15d
+            retentionSize: "45GB"
+
+            # Resource limits
+            resources:
+              requests:
+                cpu: 500m
+                memory: 2Gi
+              limits:
+                cpu: 2000m
+                memory: 4Gi
+
+            # Persistent storage
+            storageSpec:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 50Gi
+
+            # Scrape configuration
+            scrapeInterval: 30s
+            evaluationInterval: 30s
+
+            # Service discovery across namespaces
+            serviceMonitorSelectorNilUsesHelmValues: false
+            podMonitorSelectorNilUsesHelmValues: false
+            ruleSelectorNilUsesHelmValues: false
+
+            # Additional scrape configs for external targets
+            additionalScrapeConfigs: []
+
+            # Security context
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              fsGroup: 2000
+
+            # Pod anti-affinity
+            affinity:
+              podAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/name: prometheus
+                      topologyKey: kubernetes.io/hostname
+
+          # Prometheus service
+          service:
+            type: ClusterIP
+            port: 9090
+
+          # Ingress for Prometheus UI (optional, internal access)
+          ingress:
+            enabled: true
+            ingressClassName: nginx
+            hosts:
+              - prometheus.qawave.local
+            paths:
+              - /
+            annotations:
+              nginx.ingress.kubernetes.io/auth-type: basic
+              nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+              nginx.ingress.kubernetes.io/auth-realm: "Prometheus - Authentication Required"
+
+        # Alertmanager configuration
+        alertmanager:
+          enabled: true
+          alertmanagerSpec:
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+
+            # Persistent storage
+            storage:
+              volumeClaimTemplate:
+                spec:
+                  accessModes: ["ReadWriteOnce"]
+                  resources:
+                    requests:
+                      storage: 10Gi
+
+          # Ingress for Alertmanager
+          ingress:
+            enabled: true
+            ingressClassName: nginx
+            hosts:
+              - alertmanager.qawave.local
+            paths:
+              - /
+            annotations:
+              nginx.ingress.kubernetes.io/auth-type: basic
+              nginx.ingress.kubernetes.io/auth-secret: monitoring-basic-auth
+              nginx.ingress.kubernetes.io/auth-realm: "Alertmanager - Authentication Required"
+
+        # Grafana configuration
+        grafana:
+          enabled: true
+          adminPassword: "" # Set via secret
+          admin:
+            existingSecret: grafana-admin-credentials
+            userKey: admin-user
+            passwordKey: admin-password
+
+          # Resource limits
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+
+          # Persistent storage
+          persistence:
+            enabled: true
+            size: 10Gi
+
+          # Ingress
+          ingress:
+            enabled: true
+            ingressClassName: nginx
+            hosts:
+              - grafana.qawave.local
+            path: /
+            annotations:
+              cert-manager.io/cluster-issuer: "letsencrypt-prod"
+            tls:
+              - secretName: grafana-tls
+                hosts:
+                  - grafana.qawave.local
+
+          # Default dashboards
+          defaultDashboardsEnabled: true
+          defaultDashboardsTimezone: utc
+
+          # Additional data sources
+          additionalDataSources: []
+
+          # Sidecar for dashboard discovery
+          sidecar:
+            dashboards:
+              enabled: true
+              searchNamespace: ALL
+              label: grafana_dashboard
+              labelValue: "1"
+            datasources:
+              enabled: true
+              searchNamespace: ALL
+
+        # kube-state-metrics
+        kubeStateMetrics:
+          enabled: true
+
+        # Node exporter
+        nodeExporter:
+          enabled: true
+
+        # Prometheus Operator
+        prometheusOperator:
+          enabled: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+
+        # Default PrometheusRules (alerts)
+        defaultRules:
+          create: true
+          rules:
+            alertmanager: true
+            etcd: false  # Disable if not monitoring etcd
+            configReloaders: true
+            general: true
+            k8s: true
+            kubeApiserverAvailability: true
+            kubeApiserverBurnrate: true
+            kubeApiserverHistogram: true
+            kubeApiserverSlos: true
+            kubeControllerManager: false
+            kubelet: true
+            kubeProxy: false
+            kubePrometheusGeneral: true
+            kubePrometheusNodeRecording: true
+            kubernetesApps: true
+            kubernetesResources: true
+            kubernetesStorage: true
+            kubernetesSystem: true
+            kubeSchedulerAlerting: false
+            kubeSchedulerRecording: false
+            kubeStateMetrics: true
+            network: true
+            node: true
+            nodeExporterAlerting: true
+            nodeExporterRecording: true
+            prometheus: true
+            prometheusOperator: true
+
+        # Thanos sidecar (disabled for now)
+        thanosRuler:
+          enabled: false
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: false  # Don't auto-delete monitoring components
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks
+
+---
+# Deploy QAWave ServiceMonitors
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qawave-servicemonitors
+  namespace: argocd
+  labels:
+    app: monitoring
+    component: servicemonitors
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"  # Deploy after Prometheus
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: monitoring
+  source:
+    repoURL: https://github.com/hermanngeorge15/qawave-automation.git
+    targetRevision: main
+    path: infrastructure/kubernetes/base/monitoring/servicemonitors
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infrastructure/kubernetes/base/monitoring/README.md
+++ b/infrastructure/kubernetes/base/monitoring/README.md
@@ -1,0 +1,302 @@
+# QAWave Monitoring Stack
+
+This directory contains the monitoring configuration for QAWave using the kube-prometheus-stack.
+
+## Overview
+
+The monitoring stack provides:
+- **Prometheus**: Metrics collection, storage, and alerting rules
+- **Alertmanager**: Alert routing and notifications
+- **Grafana**: Visualization dashboards
+- **ServiceMonitors**: Automatic service discovery for QAWave components
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                          Monitoring Namespace                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐       │
+│  │   Prometheus    │────▶│   Alertmanager  │────▶│    Slack/       │       │
+│  │   (metrics)     │     │   (routing)     │     │    PagerDuty    │       │
+│  └────────┬────────┘     └─────────────────┘     └─────────────────┘       │
+│           │                                                                  │
+│           │ scrape                                                          │
+│           ▼                                                                  │
+│  ┌─────────────────────────────────────────────────────────────┐           │
+│  │                   ServiceMonitors                            │           │
+│  │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐       │           │
+│  │  │ Backend  │ │PostgreSQL│ │  Redis   │ │  Kafka   │       │           │
+│  │  └──────────┘ └──────────┘ └──────────┘ └──────────┘       │           │
+│  └─────────────────────────────────────────────────────────────┘           │
+│                                                                              │
+│  ┌─────────────────┐                                                        │
+│  │    Grafana      │◀─── Dashboards                                        │
+│  │  (visualization)│                                                        │
+│  └─────────────────┘                                                        │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+                              │
+                              │ scrape targets
+                              ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           QAWave Namespace                                   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐     │
+│  │ Backend  │  │PostgreSQL│  │  Redis   │  │  Kafka   │  │ Keycloak │     │
+│  │ :8080    │  │ :9187    │  │ :9121    │  │ :9404    │  │ :8080    │     │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────┘  └──────────┘     │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Components
+
+### Prometheus
+
+- **Version**: Latest via kube-prometheus-stack
+- **Retention**: 15 days (45GB max)
+- **Storage**: 50Gi persistent volume
+- **Scrape interval**: 30 seconds
+
+### Alertmanager
+
+- **Storage**: 10Gi persistent volume
+- **Receivers**: Configurable (Slack, PagerDuty, Email)
+
+### Grafana
+
+- **Storage**: 10Gi persistent volume
+- **Authentication**: Admin credentials via secret
+- **Dashboards**: Auto-discovered from ConfigMaps
+
+## ServiceMonitors
+
+| Service | Metrics Path | Port | Interval |
+|---------|-------------|------|----------|
+| Backend | `/actuator/prometheus` | http | 30s |
+| PostgreSQL | `/metrics` | metrics | 30s |
+| Redis | `/metrics` | metrics | 30s |
+| Kafka | `/metrics` | metrics | 30s |
+| Keycloak | `/metrics` | http | 30s |
+
+## Installation
+
+### Prerequisites
+
+1. Kubernetes cluster with ingress controller
+2. Storage class for persistent volumes
+3. cert-manager (optional, for TLS)
+
+### Deploy via ArgoCD
+
+```bash
+# Apply ArgoCD application
+kubectl apply -f infrastructure/argocd/applications/monitoring.yaml
+```
+
+### Manual Helm Installation
+
+```bash
+# Add Prometheus community Helm repo
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+# Create namespace
+kubectl create namespace monitoring
+
+# Install kube-prometheus-stack
+helm install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --values values.yaml
+```
+
+## Accessing Dashboards
+
+### Grafana
+
+- **URL**: https://grafana.qawave.local
+- **Default admin**: From `grafana-admin-credentials` secret
+
+```bash
+# Port forward for local access
+kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 3000:80
+# Access at http://localhost:3000
+```
+
+### Prometheus
+
+- **URL**: https://prometheus.qawave.local
+- **Authentication**: Basic auth via `monitoring-basic-auth` secret
+
+```bash
+# Port forward
+kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
+# Access at http://localhost:9090
+```
+
+### Alertmanager
+
+- **URL**: https://alertmanager.qawave.local
+- **Authentication**: Basic auth via `monitoring-basic-auth` secret
+
+```bash
+# Port forward
+kubectl port-forward svc/kube-prometheus-stack-alertmanager -n monitoring 9093:9093
+# Access at http://localhost:9093
+```
+
+## Configuration
+
+### Adding Custom Alerts
+
+Create a PrometheusRule resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qawave-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: qawave.rules
+      rules:
+        - alert: QAWaveBackendDown
+          expr: up{application="qawave-backend"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "QAWave Backend is down"
+            description: "QAWave Backend has been down for more than 5 minutes."
+```
+
+### Adding Custom Dashboards
+
+Create a ConfigMap with the `grafana_dashboard: "1"` label:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: qawave-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  qawave-overview.json: |
+    {
+      "title": "QAWave Overview",
+      ...
+    }
+```
+
+## Secrets Required
+
+### Grafana Admin Credentials
+
+```bash
+kubectl create secret generic grafana-admin-credentials \
+  --namespace monitoring \
+  --from-literal=admin-user=admin \
+  --from-literal=admin-password='<your-password>'
+```
+
+### Basic Auth for Prometheus/Alertmanager
+
+```bash
+# Generate htpasswd
+htpasswd -c auth admin
+kubectl create secret generic monitoring-basic-auth \
+  --namespace monitoring \
+  --from-file=auth
+```
+
+## Metrics Reference
+
+### Backend (Spring Boot)
+
+| Metric | Description |
+|--------|-------------|
+| `http_server_requests_seconds` | HTTP request latency |
+| `jvm_memory_used_bytes` | JVM memory usage |
+| `r2dbc_pool_acquired` | Database connection pool |
+| `spring_kafka_listener_*` | Kafka consumer metrics |
+
+### PostgreSQL
+
+| Metric | Description |
+|--------|-------------|
+| `pg_stat_database_*` | Database statistics |
+| `pg_stat_user_tables_*` | Table statistics |
+| `pg_settings_*` | PostgreSQL settings |
+
+### Redis
+
+| Metric | Description |
+|--------|-------------|
+| `redis_connected_clients` | Connected clients |
+| `redis_memory_used_bytes` | Memory usage |
+| `redis_commands_total` | Command execution |
+
+### Kafka
+
+| Metric | Description |
+|--------|-------------|
+| `kafka_server_*` | Broker metrics |
+| `kafka_consumer_*` | Consumer metrics |
+| `kafka_producer_*` | Producer metrics |
+
+## Troubleshooting
+
+### Prometheus Not Scraping Targets
+
+1. Check ServiceMonitor selector matches service labels
+2. Verify endpoint port name matches
+3. Check network policies allow scraping
+
+```bash
+# Check discovered targets
+kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
+# Visit http://localhost:9090/targets
+```
+
+### Grafana Dashboard Not Loading
+
+1. Check datasource configuration
+2. Verify Prometheus is reachable from Grafana
+3. Check dashboard JSON syntax
+
+### Alerts Not Firing
+
+1. Verify PrometheusRule is loaded
+2. Check alert expression in Prometheus UI
+3. Verify Alertmanager receiver configuration
+
+## Useful Commands
+
+```bash
+# List all ServiceMonitors
+kubectl get servicemonitors -A
+
+# Check Prometheus targets
+kubectl exec -it -n monitoring prometheus-kube-prometheus-stack-prometheus-0 -- \
+  promtool query instant http://localhost:9090 'up'
+
+# View Alertmanager configuration
+kubectl get secret -n monitoring alertmanager-kube-prometheus-stack-alertmanager -o jsonpath='{.data.alertmanager\.yaml}' | base64 -d
+
+# Check Grafana logs
+kubectl logs -n monitoring -l app.kubernetes.io/name=grafana -f
+```
+
+## References
+
+- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [Grafana Documentation](https://grafana.com/docs/)
+- [Spring Boot Actuator Metrics](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html)

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/backend-servicemonitor.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/backend-servicemonitor.yaml
@@ -1,0 +1,63 @@
+# ServiceMonitor for QAWave Backend API
+# Scrapes Spring Boot Actuator metrics from /actuator/prometheus
+#
+# Expected metrics:
+#   - JVM metrics (memory, gc, threads)
+#   - HTTP server metrics (requests, latency)
+#   - Database connection pool metrics
+#   - Custom application metrics
+#
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: qawave-backend
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: qawave-backend
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  # Selector matches the backend service
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/part-of: qawave
+
+  # Look for services in the qawave namespace
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  # Endpoint configuration
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+
+      # Relabeling to add useful labels
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - action: replace
+          targetLabel: application
+          replacement: qawave-backend
+
+      # Metric relabeling for optimization
+      metricRelabelings:
+        # Drop high-cardinality metrics if needed
+        - sourceLabels: [__name__]
+          regex: 'jvm_gc_pause_seconds_count|jvm_gc_pause_seconds_sum'
+          action: drop
+        # Keep all other metrics
+        - sourceLabels: [__name__]
+          regex: '.*'
+          action: keep
+
+  # Job label
+  jobLabel: app.kubernetes.io/name

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/kafka-servicemonitor.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/kafka-servicemonitor.yaml
@@ -1,0 +1,135 @@
+# ServiceMonitor for Apache Kafka
+# Scrapes JMX metrics via kafka_exporter or Strimzi metrics
+#
+# For Strimzi-managed Kafka:
+#   - Uses built-in Prometheus metrics export
+#
+# Expected metrics:
+#   - kafka_server_* (broker metrics)
+#   - kafka_controller_* (controller metrics)
+#   - kafka_network_* (network metrics)
+#   - kafka_log_* (log metrics)
+#   - kafka_consumer_* (consumer group metrics)
+#
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kafka
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  # Selector matches Kafka service
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka
+
+  # Look in qawave namespace
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  # Endpoint configuration
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 15s
+      scheme: http
+
+      # Relabeling
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - action: replace
+          targetLabel: application
+          replacement: kafka
+
+      # Metric relabeling
+      metricRelabelings:
+        # Keep important Kafka metrics
+        - sourceLabels: [__name__]
+          regex: 'kafka_(server|controller|network|log|consumer|producer)_.*'
+          action: keep
+
+  jobLabel: app.kubernetes.io/name
+
+---
+# ServiceMonitor for Strimzi Kafka (if using Strimzi operator)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: strimzi-kafka
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: strimzi-kafka
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+    strimzi.io/cluster: qawave-kafka
+spec:
+  # Selector for Strimzi-managed Kafka
+  selector:
+    matchLabels:
+      strimzi.io/kind: Kafka
+
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  endpoints:
+    - port: tcp-prometheus
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 15s
+
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - action: replace
+          targetLabel: application
+          replacement: strimzi-kafka
+
+  jobLabel: strimzi.io/cluster
+
+---
+# PodMonitor for Kafka brokers
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kafka-brokers
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: podmonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka
+
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 15s
+
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - action: replace
+          targetLabel: application
+          replacement: kafka

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/keycloak-servicemonitor.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/keycloak-servicemonitor.yaml
@@ -1,0 +1,92 @@
+# ServiceMonitor for Keycloak Identity Server
+# Scrapes Quarkus/Micrometer metrics from /metrics endpoint
+#
+# Expected metrics:
+#   - keycloak_* (Keycloak specific)
+#   - http_server_* (HTTP server metrics)
+#   - jvm_* (JVM metrics)
+#   - process_* (Process metrics)
+#
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keycloak
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  # Selector matches Keycloak service
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+
+  # Look in qawave namespace
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  # Endpoint configuration
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+
+      # Relabeling
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - action: replace
+          targetLabel: application
+          replacement: keycloak
+
+      # Metric relabeling
+      metricRelabelings:
+        # Keep Keycloak and JVM metrics
+        - sourceLabels: [__name__]
+          regex: '(keycloak|http_server|jvm|process)_.*'
+          action: keep
+
+  jobLabel: app.kubernetes.io/name
+
+---
+# PodMonitor for Keycloak pods with annotations
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: keycloak-pods
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: podmonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  podMetricsEndpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - action: replace
+          targetLabel: application
+          replacement: keycloak

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/kustomization.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/kustomization.yaml
@@ -1,0 +1,20 @@
+# Kustomization for QAWave ServiceMonitors
+# These ServiceMonitors tell Prometheus how to scrape metrics from QAWave services
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: qawave-monitoring
+    includeSelectors: false
+
+resources:
+  - backend-servicemonitor.yaml
+  - postgresql-servicemonitor.yaml
+  - redis-servicemonitor.yaml
+  - kafka-servicemonitor.yaml
+  - keycloak-servicemonitor.yaml

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/postgresql-servicemonitor.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/postgresql-servicemonitor.yaml
@@ -1,0 +1,89 @@
+# ServiceMonitor for PostgreSQL
+# Scrapes postgres_exporter metrics
+#
+# Note: Requires postgres_exporter sidecar or separate deployment
+# The exporter is typically deployed alongside PostgreSQL
+#
+# Expected metrics:
+#   - pg_stat_database_* (database statistics)
+#   - pg_stat_user_tables_* (table statistics)
+#   - pg_settings_* (configuration)
+#   - pg_stat_replication_* (replication status)
+#
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: postgresql
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  # Selector matches PostgreSQL service
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+
+  # Look in qawave namespace
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  # Endpoint configuration
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+
+      # Relabeling
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - action: replace
+          targetLabel: application
+          replacement: postgresql
+
+  jobLabel: app.kubernetes.io/name
+
+---
+# PodMonitor for cases where PostgreSQL doesn't expose a metrics service
+# This scrapes directly from pod annotations
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgresql-pods
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: podmonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - action: replace
+          targetLabel: application
+          replacement: postgresql

--- a/infrastructure/kubernetes/base/monitoring/servicemonitors/redis-servicemonitor.yaml
+++ b/infrastructure/kubernetes/base/monitoring/servicemonitors/redis-servicemonitor.yaml
@@ -1,0 +1,95 @@
+# ServiceMonitor for Redis
+# Scrapes redis_exporter metrics
+#
+# Note: Requires redis_exporter sidecar or separate deployment
+#
+# Expected metrics:
+#   - redis_commands_* (command statistics)
+#   - redis_connected_clients (client connections)
+#   - redis_memory_* (memory usage)
+#   - redis_keyspace_* (keyspace statistics)
+#   - redis_db_keys (keys per database)
+#
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redis
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: servicemonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  # Selector matches Redis service
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+
+  # Look in qawave namespace
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  # Endpoint configuration
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      scheme: http
+
+      # Relabeling
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_service_name]
+          targetLabel: service
+        - action: replace
+          targetLabel: application
+          replacement: redis
+
+      # Metric relabeling
+      metricRelabelings:
+        # Keep important Redis metrics
+        - sourceLabels: [__name__]
+          regex: 'redis_(commands_total|connected_clients|memory_used_bytes|keyspace_hits_total|keyspace_misses_total|db_keys|blocked_clients|evicted_keys_total|expired_keys_total|uptime_in_seconds)'
+          action: keep
+
+  jobLabel: app.kubernetes.io/name
+
+---
+# PodMonitor for Redis pods
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: redis-pods
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: podmonitor
+    app.kubernetes.io/part-of: qawave
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+
+  namespaceSelector:
+    matchNames:
+      - qawave
+
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - action: replace
+          targetLabel: application
+          replacement: redis


### PR DESCRIPTION
## Summary

- Deploys kube-prometheus-stack via ArgoCD for comprehensive monitoring
- Configures ServiceMonitors for automatic metrics collection from all QAWave services
- Includes Grafana dashboards, Alertmanager, and persistent storage

## Changes

### ArgoCD Applications (`infrastructure/argocd/applications/monitoring.yaml`)

**AppProject: monitoring**
- Separate project for monitoring resources
- RBAC permissions for CRDs, ClusterRoles, Webhooks

**Application: kube-prometheus-stack**
- Helm chart version 67.x
- Prometheus with 15-day retention, 50Gi storage
- Alertmanager with 10Gi storage
- Grafana with persistent storage and ingress
- Default Kubernetes alerts enabled

**Application: qawave-servicemonitors**
- Deploys all ServiceMonitors from repository

### ServiceMonitors

| Service | Metrics Endpoint | Interval |
|---------|-----------------|----------|
| Backend | `/actuator/prometheus` | 30s |
| PostgreSQL | `/metrics` | 30s |
| Redis | `/metrics` | 30s |
| Kafka | `/metrics` | 30s |
| Keycloak | `/metrics` | 30s |

### Configuration Highlights

- **Prometheus**: 500m-2 CPU, 2-4Gi memory, 50Gi storage
- **Alertmanager**: 100m-500m CPU, 256-512Mi memory, 10Gi storage
- **Grafana**: 250m-1 CPU, 512Mi-1Gi memory, 10Gi storage
- **Ingress**: TLS enabled for Grafana, basic auth for Prometheus/Alertmanager

## Acceptance Criteria from #144

- [x] Prometheus deployed to Kubernetes
- [x] ServiceMonitor for backend application
- [x] ServiceMonitor for PostgreSQL
- [x] ServiceMonitor for Redis
- [x] ServiceMonitor for Kafka
- [x] Persistent storage for metrics (50Gi)
- [x] Retention policy configured (15 days)
- [x] Resource limits set
- [x] Documented in README

## Prerequisites for Deployment

1. Create `grafana-admin-credentials` secret
2. Create `monitoring-basic-auth` secret for basic auth
3. Storage class available for persistent volumes

## Test Plan

- [ ] Apply ArgoCD applications
- [ ] Verify Prometheus pod starts
- [ ] Check targets are being scraped
- [ ] Access Grafana at grafana.qawave.local
- [ ] Verify default dashboards load

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)