### PR TITLE
[QA] feat: add ScenariosPage and CreatePackageModal page objects (#177)

### DIFF
--- a/e2e-tests/src/pages/CreatePackageModal.ts
+++ b/e2e-tests/src/pages/CreatePackageModal.ts
@@ -1,0 +1,200 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Data structure for creating a package
+ */
+export interface PackageFormData {
+  name: string;
+  specUrl: string;
+  baseUrl?: string;
+  description?: string;
+}
+
+/**
+ * Create Package Modal page object model
+ */
+export class CreatePackageModal {
+  readonly page: Page;
+
+  // Modal container
+  readonly modal: Locator;
+
+  // Form fields
+  readonly nameInput: Locator;
+  readonly specUrlInput: Locator;
+  readonly baseUrlInput: Locator;
+  readonly descriptionInput: Locator;
+
+  // Buttons
+  readonly submitButton: Locator;
+  readonly cancelButton: Locator;
+  readonly closeButton: Locator;
+
+  // Validation errors
+  readonly nameError: Locator;
+  readonly specUrlError: Locator;
+  readonly baseUrlError: Locator;
+
+  // Loading state
+  readonly loadingSpinner: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.modal = page.getByRole('dialog');
+
+    // Form fields by label
+    this.nameInput = this.modal.getByLabel('Name');
+    this.specUrlInput = this.modal.getByLabel('Spec URL');
+    this.baseUrlInput = this.modal.getByLabel('Base URL');
+    this.descriptionInput = this.modal.getByLabel('Description');
+
+    // Buttons
+    this.submitButton = this.modal.getByRole('button', { name: 'Create' });
+    this.cancelButton = this.modal.getByRole('button', { name: 'Cancel' });
+    this.closeButton = this.modal.getByRole('button', { name: 'Close' });
+
+    // Error messages
+    this.nameError = this.modal.getByTestId('name-error');
+    this.specUrlError = this.modal.getByTestId('spec-url-error');
+    this.baseUrlError = this.modal.getByTestId('base-url-error');
+
+    // Loading
+    this.loadingSpinner = this.modal.getByTestId('loading-spinner');
+  }
+
+  /**
+   * Wait for modal to be visible
+   */
+  async waitForVisible(): Promise<void> {
+    await this.modal.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Wait for modal to be hidden
+   */
+  async waitForHidden(): Promise<void> {
+    await this.modal.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Check if modal is visible
+   */
+  async isVisible(): Promise<boolean> {
+    return this.modal.isVisible();
+  }
+
+  /**
+   * Fill the package form with data
+   */
+  async fillForm(data: PackageFormData): Promise<void> {
+    await this.nameInput.fill(data.name);
+    await this.specUrlInput.fill(data.specUrl);
+
+    if (data.baseUrl) {
+      await this.baseUrlInput.fill(data.baseUrl);
+    }
+
+    if (data.description) {
+      await this.descriptionInput.fill(data.description);
+    }
+  }
+
+  /**
+   * Clear all form fields
+   */
+  async clearForm(): Promise<void> {
+    await this.nameInput.clear();
+    await this.specUrlInput.clear();
+    await this.baseUrlInput.clear();
+    await this.descriptionInput.clear();
+  }
+
+  /**
+   * Submit the form
+   */
+  async submit(): Promise<void> {
+    await this.submitButton.click();
+  }
+
+  /**
+   * Cancel and close modal
+   */
+  async cancel(): Promise<void> {
+    await this.cancelButton.click();
+  }
+
+  /**
+   * Close modal via X button
+   */
+  async close(): Promise<void> {
+    await this.closeButton.click();
+  }
+
+  /**
+   * Fill form and submit
+   */
+  async createPackage(data: PackageFormData): Promise<void> {
+    await this.fillForm(data);
+    await this.submit();
+  }
+
+  /**
+   * Check if submit button is enabled
+   */
+  async isSubmitEnabled(): Promise<boolean> {
+    return this.submitButton.isEnabled();
+  }
+
+  /**
+   * Check if form has validation errors
+   */
+  async hasValidationErrors(): Promise<boolean> {
+    const nameErrorVisible = await this.nameError.isVisible();
+    const specUrlErrorVisible = await this.specUrlError.isVisible();
+    const baseUrlErrorVisible = await this.baseUrlError.isVisible();
+    return nameErrorVisible || specUrlErrorVisible || baseUrlErrorVisible;
+  }
+
+  /**
+   * Get name validation error text
+   */
+  async getNameError(): Promise<string | null> {
+    if (await this.nameError.isVisible()) {
+      return this.nameError.textContent();
+    }
+    return null;
+  }
+
+  /**
+   * Get spec URL validation error text
+   */
+  async getSpecUrlError(): Promise<string | null> {
+    if (await this.specUrlError.isVisible()) {
+      return this.specUrlError.textContent();
+    }
+    return null;
+  }
+
+  /**
+   * Get base URL validation error text
+   */
+  async getBaseUrlError(): Promise<string | null> {
+    if (await this.baseUrlError.isVisible()) {
+      return this.baseUrlError.textContent();
+    }
+    return null;
+  }
+
+  /**
+   * Wait for form submission to complete (loading spinner hidden)
+   */
+  async waitForSubmission(): Promise<void> {
+    // Wait for spinner to appear and disappear
+    await this.loadingSpinner.waitFor({ state: 'visible', timeout: 5000 }).catch(() => {
+      // Spinner might not appear if submission is fast
+    });
+    await this.loadingSpinner.waitFor({ state: 'hidden', timeout: 30000 }).catch(() => {
+      // Spinner might already be hidden
+    });
+  }
+}

--- a/e2e-tests/src/pages/ScenariosPage.ts
+++ b/e2e-tests/src/pages/ScenariosPage.ts
@@ -1,0 +1,147 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './BasePage';
+
+/**
+ * Scenarios list page object model
+ */
+export class ScenariosPage extends BasePage {
+  readonly url = '/scenarios';
+
+  // Locators
+  readonly scenarioCards: Locator;
+  readonly searchInput: Locator;
+  readonly loadingSpinner: Locator;
+  readonly emptyState: Locator;
+  readonly errorMessage: Locator;
+  readonly refreshButton: Locator;
+  readonly filterDropdown: Locator;
+  readonly pagination: Locator;
+  readonly packageFilter: Locator;
+  readonly statusFilter: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.scenarioCards = page.getByTestId('scenario-card');
+    this.searchInput = page.getByPlaceholder('Search scenarios...');
+    this.loadingSpinner = page.getByTestId('loading-spinner');
+    this.emptyState = page.getByTestId('empty-state');
+    this.errorMessage = page.getByRole('alert');
+    this.refreshButton = page.getByRole('button', { name: 'Refresh' });
+    this.filterDropdown = page.getByTestId('filter-dropdown');
+    this.pagination = page.getByTestId('pagination');
+    this.packageFilter = page.getByTestId('package-filter');
+    this.statusFilter = page.getByTestId('status-filter');
+  }
+
+  /**
+   * Wait for scenarios to finish loading
+   */
+  async waitForScenariosLoaded(): Promise<void> {
+    await this.loadingSpinner.waitFor({ state: 'hidden', timeout: 30000 });
+  }
+
+  /**
+   * Get count of visible scenario cards
+   */
+  async getScenarioCount(): Promise<number> {
+    await this.waitForScenariosLoaded();
+    return this.scenarioCards.count();
+  }
+
+  /**
+   * Search for scenarios by name
+   */
+  async searchScenarios(query: string): Promise<void> {
+    await this.searchInput.fill(query);
+    await this.page.keyboard.press('Enter');
+    await this.waitForScenariosLoaded();
+  }
+
+  /**
+   * Clear search input
+   */
+  async clearSearch(): Promise<void> {
+    await this.searchInput.clear();
+    await this.page.keyboard.press('Enter');
+    await this.waitForScenariosLoaded();
+  }
+
+  /**
+   * Select a scenario by name
+   */
+  async selectScenario(name: string): Promise<void> {
+    await this.scenarioCards.filter({ hasText: name }).click();
+  }
+
+  /**
+   * Get scenario card by index
+   */
+  getScenarioCardByIndex(index: number): Locator {
+    return this.scenarioCards.nth(index);
+  }
+
+  /**
+   * Get scenario names from visible cards
+   */
+  async getScenarioNames(): Promise<string[]> {
+    await this.waitForScenariosLoaded();
+    const cards = await this.scenarioCards.all();
+    const names: string[] = [];
+    for (const card of cards) {
+      const nameElement = card.getByTestId('scenario-name');
+      const name = await nameElement.textContent();
+      if (name) names.push(name);
+    }
+    return names;
+  }
+
+  /**
+   * Check if empty state is displayed
+   */
+  async isEmptyStateVisible(): Promise<boolean> {
+    return this.emptyState.isVisible();
+  }
+
+  /**
+   * Filter scenarios by package
+   */
+  async filterByPackage(packageName: string): Promise<void> {
+    await this.packageFilter.click();
+    await this.page.getByRole('option', { name: packageName }).click();
+    await this.waitForScenariosLoaded();
+  }
+
+  /**
+   * Filter scenarios by status
+   */
+  async filterByStatus(status: 'active' | 'draft' | 'archived'): Promise<void> {
+    await this.statusFilter.click();
+    await this.page.getByRole('option', { name: status, exact: false }).click();
+    await this.waitForScenariosLoaded();
+  }
+
+  /**
+   * Refresh the scenarios list
+   */
+  async refresh(): Promise<void> {
+    await this.refreshButton.click();
+    await this.waitForScenariosLoaded();
+  }
+
+  /**
+   * Check if scenario with name exists
+   */
+  async scenarioExists(name: string): Promise<boolean> {
+    const names = await this.getScenarioNames();
+    return names.includes(name);
+  }
+
+  /**
+   * Get scenario status by name
+   */
+  async getScenarioStatus(name: string): Promise<string | null> {
+    const card = this.scenarioCards.filter({ hasText: name });
+    const status = card.getByTestId('scenario-status');
+    return status.textContent();
+  }
+}

--- a/e2e-tests/src/pages/index.ts
+++ b/e2e-tests/src/pages/index.ts
@@ -6,3 +6,5 @@ export { LoginPage } from './LoginPage';
 export { PackagesPage } from './PackagesPage';
 export { PackageDetailPage } from './PackageDetailPage';
 export { RunDetailPage } from './RunDetailPage';
+export { ScenariosPage } from './ScenariosPage';
+export { CreatePackageModal, type PackageFormData } from './CreatePackageModal';


### PR DESCRIPTION
## Summary
- Add ScenariosPage POM for the scenarios list page
- Add CreatePackageModal POM for the create package modal
- Update pages/index.ts to export new POMs

## Changes

### ScenariosPage POM
- Locators for scenario cards, search, filters, pagination
- Methods: searchScenarios, filterByPackage, filterByStatus
- Waiters and helpers for async operations

### CreatePackageModal POM
- Form fields: name, specUrl, baseUrl, description
- Validation error locators
- Methods: fillForm, createPackage, hasValidationErrors
- Wait strategies for form submission

## Acceptance Criteria Completed
- [x] BasePage class with common methods (existed)
- [x] LoginPage POM (existed)
- [x] PackagesListPage POM (existed)
- [x] PackageDetailPage POM (existed)
- [x] RunDetailPage POM (existed)
- [x] ScenariosPage POM (NEW)
- [x] CreatePackageModal POM (NEW)
- [x] Navigation component helpers (via BasePage)

## Test plan
- [ ] TypeScript compilation passes
- [ ] New POMs are importable from pages/index.ts

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)