### PR TITLE
[DevOps] feat: set up horizontal pod autoscaling

### DIFF
--- a/infrastructure/argocd/applications/autoscaling.yaml
+++ b/infrastructure/argocd/applications/autoscaling.yaml
@@ -1,0 +1,36 @@
+# ArgoCD Application for Autoscaling Resources
+# HPAs and PDBs for QAWave services
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: qawave-autoscaling
+  namespace: argocd
+  labels:
+    app: qawave
+    component: autoscaling
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"  # Deploy after main apps
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: qawave
+  source:
+    repoURL: https://github.com/hermanngeorge15/qawave-automation.git
+    targetRevision: main
+    path: infrastructure/kubernetes/base/autoscaling
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: qawave
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m

--- a/infrastructure/kubernetes/base/autoscaling/README.md
+++ b/infrastructure/kubernetes/base/autoscaling/README.md
@@ -1,0 +1,168 @@
+# Autoscaling Configuration for QAWave
+
+This directory contains HorizontalPodAutoscalers (HPA) and PodDisruptionBudgets (PDB) for QAWave services.
+
+## Overview
+
+### HorizontalPodAutoscalers
+
+HPAs automatically scale pod replicas based on observed metrics (CPU, memory, custom metrics).
+
+| Service | Min Replicas | Max Replicas | CPU Target | Memory Target |
+|---------|--------------|--------------|------------|---------------|
+| Backend | 2 | 10 | 70% | 80% |
+| Frontend | 2 | 6 | 75% | 85% |
+| Keycloak | 1 | 4 | 70% | 75% |
+
+### PodDisruptionBudgets
+
+PDBs ensure minimum availability during voluntary disruptions (node maintenance, cluster upgrades).
+
+| Service | Min Available | Max Unavailable |
+|---------|---------------|-----------------|
+| Backend | 1 | - |
+| Frontend | 1 | - |
+| Keycloak | 1 | - |
+| PostgreSQL | - | 0 |
+| Redis | - | 0 |
+| Kafka | - | 1 |
+
+## Prerequisites
+
+1. **Metrics Server**: Required for CPU/memory metrics
+2. **Resource Requests**: Pods must have resource requests defined
+3. **Deployments**: Target deployments must exist
+
+### Install Metrics Server
+
+```bash
+# Check if metrics server is installed
+kubectl get deployment metrics-server -n kube-system
+
+# Install if needed (k0s usually includes it)
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+```
+
+## Scaling Behavior
+
+### Backend
+
+- **Scale Up**: Aggressive (60s stabilization)
+  - Up to 100% increase or 4 pods per minute
+- **Scale Down**: Conservative (300s stabilization)
+  - Max 25% decrease or 2 pods per minute
+
+### Frontend
+
+- **Scale Up**: Moderate (60s stabilization)
+  - Up to 2 pods per minute
+- **Scale Down**: Conservative (300s stabilization)
+  - Max 1 pod per minute
+
+### Keycloak
+
+- **Scale Up**: Very conservative (120s stabilization)
+  - Max 1 pod every 2 minutes
+- **Scale Down**: Very conservative (600s stabilization)
+  - Max 1 pod every 5 minutes
+
+## Resource Requirements
+
+Ensure deployments have proper resource requests:
+
+```yaml
+resources:
+  requests:
+    cpu: 250m      # HPA uses this for % calculation
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+```
+
+## Monitoring
+
+### Check HPA Status
+
+```bash
+# List all HPAs
+kubectl get hpa -n qawave
+
+# Describe HPA
+kubectl describe hpa qawave-backend-hpa -n qawave
+
+# Watch scaling events
+kubectl get hpa -n qawave -w
+```
+
+### Check PDB Status
+
+```bash
+# List all PDBs
+kubectl get pdb -n qawave
+
+# Check disruption status
+kubectl describe pdb backend-pdb -n qawave
+```
+
+### Metrics
+
+```bash
+# Check current pod metrics
+kubectl top pods -n qawave
+
+# Check node metrics
+kubectl top nodes
+```
+
+## Troubleshooting
+
+### HPA Shows "unknown" Metrics
+
+1. Check metrics server is running
+2. Verify resource requests are set
+3. Wait for metrics to be collected (1-2 minutes)
+
+```bash
+# Check metrics server
+kubectl get --raw "/apis/metrics.k8s.io/v1beta1/pods" | jq .
+```
+
+### Pods Not Scaling Up
+
+1. Check current metrics vs target
+2. Verify max replicas not reached
+3. Check for resource quota limits
+
+### Pods Not Scaling Down
+
+1. Check stabilization window (default 300s)
+2. Verify metrics are below target
+3. Check for incoming traffic patterns
+
+## Custom Metrics (Optional)
+
+For advanced scaling based on request rate:
+
+1. Install prometheus-adapter
+2. Configure custom metrics rules
+3. Add custom metric to HPA
+
+```yaml
+metrics:
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests_per_second
+      target:
+        type: AverageValue
+        averageValue: "100"
+```
+
+## Best Practices
+
+1. **Start Conservative**: Begin with higher utilization targets
+2. **Monitor Before Scaling**: Observe metrics before adjusting
+3. **Test Scaling**: Use load testing to verify behavior
+4. **Set Appropriate Limits**: Prevent runaway scaling
+5. **Use PDBs**: Always pair HPAs with PDBs

--- a/infrastructure/kubernetes/base/autoscaling/backend-hpa.yaml
+++ b/infrastructure/kubernetes/base/autoscaling/backend-hpa.yaml
@@ -1,0 +1,81 @@
+# HorizontalPodAutoscaler for QAWave Backend
+# Scales based on CPU, memory, and custom metrics
+#
+# Scaling behavior:
+#   - Min replicas: 2 (HA)
+#   - Max replicas: 10
+#   - Scale up: 60s stabilization
+#   - Scale down: 300s stabilization (prevent flapping)
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: qawave-backend-hpa
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: hpa
+    app.kubernetes.io/part-of: qawave
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: backend
+  minReplicas: 2
+  maxReplicas: 10
+
+  metrics:
+    # CPU-based scaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+    # Memory-based scaling
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+    # Custom metric: requests per second (if available)
+    # Requires prometheus-adapter
+    # - type: Pods
+    #   pods:
+    #     metric:
+    #       name: http_requests_per_second
+    #     target:
+    #       type: AverageValue
+    #       averageValue: "100"
+
+  behavior:
+    # Scale up behavior
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        # Scale up 100% of current replicas every 60s
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+        # Or scale up 4 pods every 60s (whichever is higher)
+        - type: Pods
+          value: 4
+          periodSeconds: 60
+      selectPolicy: Max
+
+    # Scale down behavior (more conservative)
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        # Scale down 25% of current replicas every 60s
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+        # Or scale down 2 pods every 60s (whichever is lower)
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+      selectPolicy: Min

--- a/infrastructure/kubernetes/base/autoscaling/frontend-hpa.yaml
+++ b/infrastructure/kubernetes/base/autoscaling/frontend-hpa.yaml
@@ -1,0 +1,55 @@
+# HorizontalPodAutoscaler for QAWave Frontend
+# Scales based on CPU utilization
+#
+# Frontend is mostly static assets, lower resource requirements
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: qawave-frontend-hpa
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: hpa
+    app.kubernetes.io/part-of: qawave
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 2
+  maxReplicas: 6
+
+  metrics:
+    # CPU-based scaling
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+
+    # Memory-based scaling
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 85
+
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+      selectPolicy: Max
+
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+      selectPolicy: Min

--- a/infrastructure/kubernetes/base/autoscaling/keycloak-hpa.yaml
+++ b/infrastructure/kubernetes/base/autoscaling/keycloak-hpa.yaml
@@ -1,0 +1,56 @@
+# HorizontalPodAutoscaler for Keycloak
+# Scales based on CPU and memory
+#
+# Note: Keycloak requires session affinity for HA
+# This HPA works with distributed caching (Infinispan)
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: keycloak-hpa
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: hpa
+    app.kubernetes.io/part-of: qawave
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: keycloak
+  minReplicas: 1  # Start with 1 for development
+  maxReplicas: 4
+
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 75
+
+  behavior:
+    # Conservative scale up for auth service
+    scaleUp:
+      stabilizationWindowSeconds: 120
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+      selectPolicy: Max
+
+    # Very conservative scale down
+    scaleDown:
+      stabilizationWindowSeconds: 600
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 300
+      selectPolicy: Min

--- a/infrastructure/kubernetes/base/autoscaling/kustomization.yaml
+++ b/infrastructure/kubernetes/base/autoscaling/kustomization.yaml
@@ -1,0 +1,19 @@
+# Kustomization for Autoscaling Resources
+# HPAs and PDBs for QAWave services
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: qawave
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: qawave-autoscaling
+    includeSelectors: false
+
+resources:
+  - backend-hpa.yaml
+  - frontend-hpa.yaml
+  - keycloak-hpa.yaml
+  - pod-disruption-budgets.yaml

--- a/infrastructure/kubernetes/base/autoscaling/pod-disruption-budgets.yaml
+++ b/infrastructure/kubernetes/base/autoscaling/pod-disruption-budgets.yaml
@@ -1,0 +1,110 @@
+# Pod Disruption Budgets for QAWave
+# Ensures minimum availability during voluntary disruptions
+# (node drains, rolling updates, cluster upgrades)
+
+---
+# Backend PDB - Always keep at least 1 pod available
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+      app.kubernetes.io/part-of: qawave
+
+---
+# Frontend PDB - Always keep at least 1 pod available
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+      app.kubernetes.io/part-of: qawave
+
+---
+# Keycloak PDB - Always keep at least 1 pod available
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+
+---
+# PostgreSQL PDB - StatefulSet must always have availability
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: postgresql-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  # For single replica, allow 0 disruptions
+  # For multi-replica, use minAvailable: 1
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+
+---
+# Redis PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redis-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+
+---
+# Kafka PDB - Maintain quorum
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kafka-pdb
+  namespace: qawave
+  labels:
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/component: pdb
+    app.kubernetes.io/part-of: qawave
+spec:
+  # For 3-node Kafka cluster, allow 1 unavailable
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kafka


### PR DESCRIPTION
## Summary

Adds automatic horizontal scaling for QAWave services using Kubernetes HPA and ensures availability during maintenance with PodDisruptionBudgets.

## Changes

### HorizontalPodAutoscalers

| Service | Min | Max | CPU Target | Memory Target | Scale Up | Scale Down |
|---------|-----|-----|------------|---------------|----------|------------|
| Backend | 2 | 10 | 70% | 80% | 60s | 300s |
| Frontend | 2 | 6 | 75% | 85% | 60s | 300s |
| Keycloak | 1 | 4 | 70% | 75% | 120s | 600s |

### PodDisruptionBudgets

| Service | Availability Guarantee |
|---------|----------------------|
| Backend | minAvailable: 1 |
| Frontend | minAvailable: 1 |
| Keycloak | minAvailable: 1 |
| PostgreSQL | maxUnavailable: 0 |
| Redis | maxUnavailable: 0 |
| Kafka | maxUnavailable: 1 |

### Scaling Behavior

**Backend** (aggressive scale-up, conservative scale-down):
- Scale up: 100% or 4 pods per minute
- Scale down: 25% or 2 pods per minute

**Frontend** (moderate):
- Scale up: 2 pods per minute
- Scale down: 1 pod per minute

**Keycloak** (very conservative for auth stability):
- Scale up: 1 pod every 2 minutes
- Scale down: 1 pod every 5 minutes

## Acceptance Criteria from #201

- [x] HPA configured for backend
- [x] HPA configured for frontend
- [x] Custom metrics (ready for prometheus-adapter)
- [x] Scale-up/down policies
- [x] Pod disruption budgets
- [x] Resource requests/limits documentation

## Test Plan

- [ ] Deploy autoscaling application
- [ ] Verify HPAs show current metrics
- [ ] Load test to trigger scale-up
- [ ] Verify scale-down after load
- [ ] Test node drain with PDBs

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)