### PR TITLE
[DevOps] feat: add alerting rules and Grafana dashboards

### DIFF
--- a/infrastructure/kubernetes/base/monitoring/alerting/infrastructure-alerts.yaml
+++ b/infrastructure/kubernetes/base/monitoring/alerting/infrastructure-alerts.yaml
@@ -1,0 +1,232 @@
+# PrometheusRule for Infrastructure Alerts
+# Monitors PostgreSQL, Redis, Kafka, and Kubernetes resources
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qawave-infrastructure-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+    app.kubernetes.io/part-of: qawave
+spec:
+  groups:
+    # PostgreSQL Alerts
+    - name: qawave.postgresql
+      interval: 30s
+      rules:
+        - alert: PostgreSQLDown
+          expr: pg_up{job="postgresql"} == 0
+          for: 1m
+          labels:
+            severity: critical
+            service: postgresql
+          annotations:
+            summary: "PostgreSQL is down"
+            description: "PostgreSQL database has been down for more than 1 minute."
+
+        - alert: PostgreSQLHighConnections
+          expr: |
+            pg_stat_activity_count{job="postgresql"}
+            /
+            pg_settings_max_connections{job="postgresql"} > 0.8
+          for: 5m
+          labels:
+            severity: warning
+            service: postgresql
+          annotations:
+            summary: "PostgreSQL high connection usage"
+            description: "Connection usage is {{ $value | humanizePercentage }}"
+
+        - alert: PostgreSQLSlowQueries
+          expr: |
+            rate(pg_stat_activity_max_tx_duration{job="postgresql"}[5m]) > 60
+          for: 5m
+          labels:
+            severity: warning
+            service: postgresql
+          annotations:
+            summary: "PostgreSQL slow queries detected"
+            description: "Long-running transactions detected"
+
+        - alert: PostgreSQLReplicationLag
+          expr: pg_replication_lag{job="postgresql"} > 30
+          for: 5m
+          labels:
+            severity: warning
+            service: postgresql
+          annotations:
+            summary: "PostgreSQL replication lag"
+            description: "Replication lag is {{ $value }}s"
+
+        - alert: PostgreSQLDiskSpaceLow
+          expr: |
+            (
+              pg_database_size_bytes{job="postgresql"}
+              /
+              (1024 * 1024 * 1024 * 50)  # 50GB assumed
+            ) > 0.8
+          for: 10m
+          labels:
+            severity: warning
+            service: postgresql
+          annotations:
+            summary: "PostgreSQL disk space running low"
+            description: "Database size is approaching limit"
+
+    # Redis Alerts
+    - name: qawave.redis
+      interval: 30s
+      rules:
+        - alert: RedisDown
+          expr: redis_up{job="redis"} == 0
+          for: 1m
+          labels:
+            severity: critical
+            service: redis
+          annotations:
+            summary: "Redis is down"
+            description: "Redis cache has been down for more than 1 minute."
+
+        - alert: RedisHighMemory
+          expr: |
+            redis_memory_used_bytes{job="redis"}
+            /
+            redis_memory_max_bytes{job="redis"} > 0.85
+          for: 5m
+          labels:
+            severity: warning
+            service: redis
+          annotations:
+            summary: "Redis high memory usage"
+            description: "Memory usage is {{ $value | humanizePercentage }}"
+
+        - alert: RedisHighKeyEviction
+          expr: rate(redis_evicted_keys_total{job="redis"}[5m]) > 100
+          for: 5m
+          labels:
+            severity: warning
+            service: redis
+          annotations:
+            summary: "Redis high key eviction rate"
+            description: "Evicting {{ $value }} keys/second"
+
+        - alert: RedisSlowlog
+          expr: increase(redis_slowlog_length{job="redis"}[5m]) > 10
+          for: 5m
+          labels:
+            severity: warning
+            service: redis
+          annotations:
+            summary: "Redis slow commands detected"
+            description: "{{ $value }} slow commands in the last 5 minutes"
+
+    # Kafka Alerts
+    - name: qawave.kafka
+      interval: 30s
+      rules:
+        - alert: KafkaBrokerDown
+          expr: kafka_server_replicamanager_leadercount == 0
+          for: 1m
+          labels:
+            severity: critical
+            service: kafka
+          annotations:
+            summary: "Kafka broker is down"
+            description: "Kafka broker has no leader partitions"
+
+        - alert: KafkaUnderReplicatedPartitions
+          expr: kafka_server_replicamanager_underreplicatedpartitions > 0
+          for: 5m
+          labels:
+            severity: warning
+            service: kafka
+          annotations:
+            summary: "Kafka under-replicated partitions"
+            description: "{{ $value }} partitions are under-replicated"
+
+        - alert: KafkaConsumerLag
+          expr: |
+            kafka_consumergroup_lag_sum{group=~"qawave.*"} > 10000
+          for: 10m
+          labels:
+            severity: warning
+            service: kafka
+          annotations:
+            summary: "Kafka consumer lag is high"
+            description: "Consumer group {{ $labels.group }} has lag of {{ $value }}"
+
+        - alert: KafkaProducerErrors
+          expr: rate(kafka_producer_record_error_total[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+            service: kafka
+          annotations:
+            summary: "Kafka producer errors"
+            description: "Producer is experiencing errors"
+
+    # Kubernetes Resource Alerts
+    - name: qawave.kubernetes
+      interval: 30s
+      rules:
+        - alert: PodCrashLooping
+          expr: |
+            rate(kube_pod_container_status_restarts_total{namespace="qawave"}[15m]) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod is crash looping"
+            description: "Pod {{ $labels.pod }} is restarting frequently"
+
+        - alert: PodNotReady
+          expr: |
+            kube_pod_status_ready{namespace="qawave", condition="true"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod is not ready"
+            description: "Pod {{ $labels.pod }} has been not ready for 5 minutes"
+
+        - alert: DeploymentReplicasMismatch
+          expr: |
+            kube_deployment_spec_replicas{namespace="qawave"}
+            !=
+            kube_deployment_status_replicas_available{namespace="qawave"}
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Deployment replicas mismatch"
+            description: "Deployment {{ $labels.deployment }} has {{ $value }} available replicas"
+
+        - alert: PVCAlmostFull
+          expr: |
+            (
+              kubelet_volume_stats_used_bytes{namespace="qawave"}
+              /
+              kubelet_volume_stats_capacity_bytes{namespace="qawave"}
+            ) > 0.85
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "PVC almost full"
+            description: "PVC {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} full"
+
+        - alert: HighCPUThrottling
+          expr: |
+            (
+              sum(rate(container_cpu_cfs_throttled_seconds_total{namespace="qawave"}[5m])) by (pod)
+              /
+              sum(rate(container_cpu_cfs_periods_total{namespace="qawave"}[5m])) by (pod)
+            ) > 0.25
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High CPU throttling"
+            description: "Pod {{ $labels.pod }} is being throttled {{ $value | humanizePercentage }}"

--- a/infrastructure/kubernetes/base/monitoring/alerting/kustomization.yaml
+++ b/infrastructure/kubernetes/base/monitoring/alerting/kustomization.yaml
@@ -1,0 +1,18 @@
+# Kustomization for Prometheus Alerting Rules
+# PrometheusRule resources for QAWave monitoring
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: qawave-monitoring
+    includeSelectors: false
+
+resources:
+  - qawave-alerts.yaml
+  - infrastructure-alerts.yaml
+  - slo-alerts.yaml

--- a/infrastructure/kubernetes/base/monitoring/alerting/qawave-alerts.yaml
+++ b/infrastructure/kubernetes/base/monitoring/alerting/qawave-alerts.yaml
@@ -1,0 +1,191 @@
+# PrometheusRule for QAWave Application Alerts
+# Monitors backend, frontend, and business metrics
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qawave-application-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+    app.kubernetes.io/part-of: qawave
+spec:
+  groups:
+    # Backend Service Alerts
+    - name: qawave.backend
+      interval: 30s
+      rules:
+        # Backend is down
+        - alert: QAWaveBackendDown
+          expr: up{job="qawave-backend"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            service: backend
+          annotations:
+            summary: "QAWave Backend is down"
+            description: "QAWave Backend has been down for more than 2 minutes."
+            runbook_url: "https://docs.qawave.io/runbooks/backend-down"
+
+        # High error rate
+        - alert: QAWaveBackendHighErrorRate
+          expr: |
+            (
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend", status=~"5.."}[5m]))
+              /
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend"}[5m]))
+            ) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+            service: backend
+          annotations:
+            summary: "High error rate on QAWave Backend"
+            description: "Error rate is {{ $value | humanizePercentage }} (threshold: 5%)"
+
+        # Critical error rate
+        - alert: QAWaveBackendCriticalErrorRate
+          expr: |
+            (
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend", status=~"5.."}[5m]))
+              /
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend"}[5m]))
+            ) > 0.10
+          for: 2m
+          labels:
+            severity: critical
+            service: backend
+          annotations:
+            summary: "Critical error rate on QAWave Backend"
+            description: "Error rate is {{ $value | humanizePercentage }} (threshold: 10%)"
+
+        # High latency
+        - alert: QAWaveBackendHighLatency
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(http_server_requests_seconds_bucket{job="qawave-backend"}[5m])) by (le)
+            ) > 2
+          for: 5m
+          labels:
+            severity: warning
+            service: backend
+          annotations:
+            summary: "High latency on QAWave Backend"
+            description: "P95 latency is {{ $value | humanizeDuration }} (threshold: 2s)"
+
+        # Memory pressure
+        - alert: QAWaveBackendHighMemory
+          expr: |
+            (
+              jvm_memory_used_bytes{job="qawave-backend", area="heap"}
+              /
+              jvm_memory_max_bytes{job="qawave-backend", area="heap"}
+            ) > 0.85
+          for: 10m
+          labels:
+            severity: warning
+            service: backend
+          annotations:
+            summary: "High memory usage on QAWave Backend"
+            description: "Heap memory usage is {{ $value | humanizePercentage }}"
+
+        # Database connection pool exhausted
+        - alert: QAWaveBackendDBPoolExhausted
+          expr: |
+            r2dbc_pool_acquired{job="qawave-backend"}
+            /
+            r2dbc_pool_max_allocated{job="qawave-backend"} > 0.9
+          for: 5m
+          labels:
+            severity: warning
+            service: backend
+          annotations:
+            summary: "Database connection pool nearly exhausted"
+            description: "Connection pool usage is {{ $value | humanizePercentage }}"
+
+    # Frontend Alerts
+    - name: qawave.frontend
+      interval: 30s
+      rules:
+        - alert: QAWaveFrontendDown
+          expr: up{job="qawave-frontend"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            service: frontend
+          annotations:
+            summary: "QAWave Frontend is down"
+            description: "QAWave Frontend has been down for more than 2 minutes."
+
+        - alert: QAWaveFrontendHighErrorRate
+          expr: |
+            (
+              sum(rate(nginx_http_requests_total{job="qawave-frontend", status=~"5.."}[5m]))
+              /
+              sum(rate(nginx_http_requests_total{job="qawave-frontend"}[5m]))
+            ) > 0.05
+          for: 5m
+          labels:
+            severity: warning
+            service: frontend
+          annotations:
+            summary: "High error rate on QAWave Frontend"
+            description: "Error rate is {{ $value | humanizePercentage }}"
+
+    # Keycloak Alerts
+    - name: qawave.keycloak
+      interval: 30s
+      rules:
+        - alert: KeycloakDown
+          expr: up{job="keycloak"} == 0
+          for: 2m
+          labels:
+            severity: critical
+            service: keycloak
+          annotations:
+            summary: "Keycloak is down"
+            description: "Keycloak authentication server has been down for more than 2 minutes."
+
+        - alert: KeycloakHighLoginFailures
+          expr: |
+            sum(rate(keycloak_login_error_total[5m]))
+            /
+            sum(rate(keycloak_login_total[5m])) > 0.1
+          for: 5m
+          labels:
+            severity: warning
+            service: keycloak
+          annotations:
+            summary: "High login failure rate on Keycloak"
+            description: "Login failure rate is {{ $value | humanizePercentage }}"
+
+    # Business Metrics Alerts
+    - name: qawave.business
+      interval: 1m
+      rules:
+        - alert: QAWaveNoTestRunsCreated
+          expr: |
+            sum(increase(qawave_test_runs_created_total[1h])) == 0
+          for: 2h
+          labels:
+            severity: info
+            service: backend
+          annotations:
+            summary: "No test runs created in the last 2 hours"
+            description: "This might indicate low user activity or an issue with test creation."
+
+        - alert: QAWaveHighTestFailureRate
+          expr: |
+            (
+              sum(rate(qawave_test_runs_failed_total[1h]))
+              /
+              sum(rate(qawave_test_runs_total[1h]))
+            ) > 0.3
+          for: 30m
+          labels:
+            severity: warning
+            service: backend
+          annotations:
+            summary: "High test failure rate"
+            description: "Test failure rate is {{ $value | humanizePercentage }} in the last hour"

--- a/infrastructure/kubernetes/base/monitoring/alerting/slo-alerts.yaml
+++ b/infrastructure/kubernetes/base/monitoring/alerting/slo-alerts.yaml
@@ -1,0 +1,136 @@
+# PrometheusRule for SLO/SLI Alerts
+# Service Level Objectives monitoring
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: qawave-slo-alerts
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+    app.kubernetes.io/part-of: qawave
+spec:
+  groups:
+    # SLO Recording Rules
+    - name: qawave.slo.recording
+      interval: 30s
+      rules:
+        # API Availability (target: 99.9%)
+        - record: qawave:api:availability:ratio
+          expr: |
+            1 - (
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend", status=~"5.."}[5m]))
+              /
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend"}[5m]))
+            )
+
+        # API Latency P50 (target: < 200ms)
+        - record: qawave:api:latency:p50
+          expr: |
+            histogram_quantile(0.50,
+              sum(rate(http_server_requests_seconds_bucket{job="qawave-backend"}[5m])) by (le)
+            )
+
+        # API Latency P95 (target: < 1s)
+        - record: qawave:api:latency:p95
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(http_server_requests_seconds_bucket{job="qawave-backend"}[5m])) by (le)
+            )
+
+        # API Latency P99 (target: < 2s)
+        - record: qawave:api:latency:p99
+          expr: |
+            histogram_quantile(0.99,
+              sum(rate(http_server_requests_seconds_bucket{job="qawave-backend"}[5m])) by (le)
+            )
+
+        # Error budget remaining (monthly)
+        - record: qawave:api:error_budget:remaining
+          expr: |
+            1 - (
+              (1 - qawave:api:availability:ratio)
+              /
+              (1 - 0.999)  # 99.9% SLO
+            )
+
+    # SLO Alerts
+    - name: qawave.slo.alerts
+      interval: 1m
+      rules:
+        # Availability SLO Burn Rate (fast burn)
+        - alert: SLOAvailabilityBurnRateFast
+          expr: |
+            (
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend", status=~"5.."}[5m]))
+              /
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend"}[5m]))
+            ) > (14.4 * (1 - 0.999))
+          for: 2m
+          labels:
+            severity: critical
+            slo: availability
+          annotations:
+            summary: "SLO: Availability burn rate is very high"
+            description: "Burning through error budget 14.4x faster than allowed. Will exhaust monthly budget in 2 hours."
+
+        # Availability SLO Burn Rate (slow burn)
+        - alert: SLOAvailabilityBurnRateSlow
+          expr: |
+            (
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend", status=~"5.."}[1h]))
+              /
+              sum(rate(http_server_requests_seconds_count{job="qawave-backend"}[1h]))
+            ) > (3 * (1 - 0.999))
+          for: 15m
+          labels:
+            severity: warning
+            slo: availability
+          annotations:
+            summary: "SLO: Availability burn rate is elevated"
+            description: "Burning through error budget 3x faster than allowed. Will exhaust monthly budget in 10 days."
+
+        # Latency SLO (P95 > 1s)
+        - alert: SLOLatencyP95High
+          expr: qawave:api:latency:p95 > 1
+          for: 5m
+          labels:
+            severity: warning
+            slo: latency
+          annotations:
+            summary: "SLO: P95 latency exceeds target"
+            description: "P95 latency is {{ $value | humanizeDuration }} (target: 1s)"
+
+        # Latency SLO (P99 > 2s)
+        - alert: SLOLatencyP99High
+          expr: qawave:api:latency:p99 > 2
+          for: 5m
+          labels:
+            severity: warning
+            slo: latency
+          annotations:
+            summary: "SLO: P99 latency exceeds target"
+            description: "P99 latency is {{ $value | humanizeDuration }} (target: 2s)"
+
+        # Error budget exhausted
+        - alert: SLOErrorBudgetExhausted
+          expr: qawave:api:error_budget:remaining < 0
+          for: 5m
+          labels:
+            severity: critical
+            slo: availability
+          annotations:
+            summary: "SLO: Error budget exhausted"
+            description: "Monthly error budget has been exhausted. Current remaining: {{ $value | humanizePercentage }}"
+
+        # Error budget low
+        - alert: SLOErrorBudgetLow
+          expr: qawave:api:error_budget:remaining < 0.25
+          for: 30m
+          labels:
+            severity: warning
+            slo: availability
+          annotations:
+            summary: "SLO: Error budget is low"
+            description: "Only {{ $value | humanizePercentage }} of error budget remaining for this month"

--- a/infrastructure/kubernetes/base/monitoring/dashboards/kustomization.yaml
+++ b/infrastructure/kubernetes/base/monitoring/dashboards/kustomization.yaml
@@ -1,0 +1,40 @@
+# Kustomization for Grafana Dashboards
+# ConfigMaps with dashboard JSON for auto-provisioning
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+labels:
+  - pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: qawave-monitoring
+    includeSelectors: false
+
+# Note: Large JSON dashboards are generated separately
+# This kustomization references the ConfigMap generator
+configMapGenerator:
+  - name: qawave-overview-dashboard
+    files:
+      - qawave-overview.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+
+  - name: qawave-backend-dashboard
+    files:
+      - qawave-backend.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+
+  - name: qawave-infrastructure-dashboard
+    files:
+      - qawave-infrastructure.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/infrastructure/kubernetes/base/monitoring/dashboards/qawave-backend.json
+++ b/infrastructure/kubernetes/base/monitoring/dashboards/qawave-backend.json
@@ -1,0 +1,123 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "content": "# QAWave Backend Metrics\nSpring Boot application metrics including JVM, HTTP, and database.", "mode": "markdown" },
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 3 },
+      "id": 10,
+      "title": "JVM Metrics",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 4 },
+      "id": 2,
+      "targets": [
+        { "expr": "jvm_memory_used_bytes{job=\"qawave-backend\", area=\"heap\"} / 1024 / 1024", "legendFormat": "Used", "refId": "A" },
+        { "expr": "jvm_memory_max_bytes{job=\"qawave-backend\", area=\"heap\"} / 1024 / 1024", "legendFormat": "Max", "refId": "B" }
+      ],
+      "title": "Heap Memory (MB)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 4 },
+      "id": 3,
+      "targets": [
+        { "expr": "jvm_threads_live_threads{job=\"qawave-backend\"}", "legendFormat": "Live", "refId": "A" },
+        { "expr": "jvm_threads_peak_threads{job=\"qawave-backend\"}", "legendFormat": "Peak", "refId": "B" }
+      ],
+      "title": "JVM Threads",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 4 },
+      "id": 4,
+      "targets": [
+        { "expr": "rate(jvm_gc_pause_seconds_sum{job=\"qawave-backend\"}[5m])", "legendFormat": "{{ action }}", "refId": "A" }
+      ],
+      "title": "GC Pause Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
+      "id": 11,
+      "title": "HTTP Metrics",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 11 },
+      "id": 5,
+      "targets": [
+        { "expr": "sum(rate(http_server_requests_seconds_count{job=\"qawave-backend\"}[5m])) by (status)", "legendFormat": "{{ status }}", "refId": "A" }
+      ],
+      "title": "Requests by Status Code",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 11 },
+      "id": 6,
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le, uri))", "legendFormat": "P50 {{ uri }}", "refId": "A" },
+        { "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le, uri))", "legendFormat": "P95 {{ uri }}", "refId": "B" }
+      ],
+      "title": "Latency by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 12,
+      "title": "Database Metrics",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 18 },
+      "id": 7,
+      "targets": [
+        { "expr": "r2dbc_pool_acquired{job=\"qawave-backend\"}", "legendFormat": "Acquired", "refId": "A" },
+        { "expr": "r2dbc_pool_pending{job=\"qawave-backend\"}", "legendFormat": "Pending", "refId": "B" },
+        { "expr": "r2dbc_pool_idle{job=\"qawave-backend\"}", "legendFormat": "Idle", "refId": "C" }
+      ],
+      "title": "Connection Pool",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 18 },
+      "id": 8,
+      "targets": [
+        { "expr": "rate(r2dbc_pool_acquired_total{job=\"qawave-backend\"}[5m])", "legendFormat": "Connections/sec", "refId": "A" }
+      ],
+      "title": "Connection Acquisition Rate",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 18 },
+      "id": 9,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "expr": "(r2dbc_pool_acquired{job=\"qawave-backend\"} / r2dbc_pool_max_allocated{job=\"qawave-backend\"}) * 100", "refId": "A" }
+      ],
+      "title": "Pool Utilization %",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["qawave", "backend", "spring-boot"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "QAWave Backend",
+  "uid": "qawave-backend",
+  "version": 1
+}

--- a/infrastructure/kubernetes/base/monitoring/dashboards/qawave-infrastructure.json
+++ b/infrastructure/kubernetes/base/monitoring/dashboards/qawave-infrastructure.json
@@ -1,0 +1,140 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "content": "# QAWave Infrastructure\nPostgreSQL, Redis, and Kafka metrics.", "mode": "markdown" },
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 3 },
+      "id": 20,
+      "title": "PostgreSQL",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 4 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{ "expr": "pg_up{job=\"postgresql\"}", "refId": "A" }],
+      "title": "PostgreSQL Status",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 4 },
+      "id": 3,
+      "targets": [{ "expr": "pg_stat_activity_count{job=\"postgresql\"}", "legendFormat": "Connections", "refId": "A" }],
+      "title": "Active Connections",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 4 },
+      "id": 4,
+      "targets": [
+        { "expr": "rate(pg_stat_database_xact_commit{job=\"postgresql\"}[5m])", "legendFormat": "Commits", "refId": "A" },
+        { "expr": "rate(pg_stat_database_xact_rollback{job=\"postgresql\"}[5m])", "legendFormat": "Rollbacks", "refId": "B" }
+      ],
+      "title": "Transactions/sec",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 4 },
+      "id": 5,
+      "targets": [{ "expr": "pg_database_size_bytes{job=\"postgresql\"} / 1024 / 1024 / 1024", "legendFormat": "{{ datname }}", "refId": "A" }],
+      "title": "Database Size (GB)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 21,
+      "title": "Redis",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 10 },
+      "id": 6,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{ "expr": "redis_up{job=\"redis\"}", "refId": "A" }],
+      "title": "Redis Status",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 10 },
+      "id": 7,
+      "targets": [{ "expr": "redis_memory_used_bytes{job=\"redis\"} / 1024 / 1024", "legendFormat": "Memory", "refId": "A" }],
+      "title": "Memory Usage (MB)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 10 },
+      "id": 8,
+      "targets": [{ "expr": "redis_connected_clients{job=\"redis\"}", "legendFormat": "Clients", "refId": "A" }],
+      "title": "Connected Clients",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 10 },
+      "id": 9,
+      "targets": [
+        { "expr": "rate(redis_keyspace_hits_total{job=\"redis\"}[5m])", "legendFormat": "Hits", "refId": "A" },
+        { "expr": "rate(redis_keyspace_misses_total{job=\"redis\"}[5m])", "legendFormat": "Misses", "refId": "B" }
+      ],
+      "title": "Cache Hit/Miss Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "id": 22,
+      "title": "Kafka",
+      "type": "row"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 16 },
+      "id": 10,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{ "expr": "kafka_server_replicamanager_leadercount", "refId": "A" }],
+      "title": "Leader Partitions",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 16 },
+      "id": 11,
+      "targets": [{ "expr": "sum(kafka_server_replicamanager_underreplicatedpartitions)", "legendFormat": "Under-replicated", "refId": "A" }],
+      "title": "Under-replicated Partitions",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 16 },
+      "id": 12,
+      "targets": [{ "expr": "sum(kafka_consumergroup_lag_sum{group=~\"qawave.*\"}) by (group)", "legendFormat": "{{ group }}", "refId": "A" }],
+      "title": "Consumer Lag",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 16 },
+      "id": 13,
+      "targets": [
+        { "expr": "sum(rate(kafka_server_brokertopicmetrics_messagesin_total[5m])) by (topic)", "legendFormat": "{{ topic }}", "refId": "A" }
+      ],
+      "title": "Messages In/sec",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["qawave", "infrastructure", "postgresql", "redis", "kafka"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "QAWave Infrastructure",
+  "uid": "qawave-infra",
+  "version": 1
+}

--- a/infrastructure/kubernetes/base/monitoring/dashboards/qawave-overview.json
+++ b/infrastructure/kubernetes/base/monitoring/dashboards/qawave-overview.json
@@ -1,0 +1,182 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": { "h": 3, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "content": "# QAWave System Overview\nReal-time monitoring of QAWave platform health and performance.",
+        "mode": "markdown"
+      },
+      "type": "text"
+    },
+    {
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 3 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(up{job=~\"qawave-.*\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Services Up",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 3 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"qawave-backend\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 3 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le)) * 1000",
+          "refId": "A"
+        }
+      ],
+      "title": "P95 Latency (ms)",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 3 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        }
+      },
+      "targets": [
+        {
+          "expr": "(sum(rate(http_server_requests_seconds_count{job=\"qawave-backend\", status=~\"5..\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=\"qawave-backend\"}[5m]))) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate %",
+      "type": "stat"
+    },
+    {
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"qawave-backend\"}[5m])) by (uri)",
+          "legendFormat": "{{ uri }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "id": 7,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{job=\"qawave-backend\"}[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "title": "Response Time Distribution",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"qawave\"}) by (pod) / 1024 / 1024",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage by Pod (MB)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"qawave\"}[5m])) by (pod) * 100",
+          "legendFormat": "{{ pod }}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage by Pod (%)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["qawave", "overview"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "QAWave Overview",
+  "uid": "qawave-overview",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Adds comprehensive Prometheus alerting rules and Grafana dashboards for QAWave monitoring.

## Alerting Rules

### Application Alerts (`qawave-alerts.yaml`)
| Alert | Severity | Condition |
|-------|----------|-----------|
| QAWaveBackendDown | Critical | Service unavailable >2m |
| QAWaveBackendHighErrorRate | Warning | Error rate >5% |
| QAWaveBackendCriticalErrorRate | Critical | Error rate >10% |
| QAWaveBackendHighLatency | Warning | P95 >2s |
| QAWaveBackendHighMemory | Warning | Heap >85% |
| QAWaveBackendDBPoolExhausted | Warning | Pool >90% |
| KeycloakDown | Critical | Auth unavailable |

### Infrastructure Alerts (`infrastructure-alerts.yaml`)
- **PostgreSQL**: Down, high connections, slow queries, replication lag
- **Redis**: Down, high memory, eviction rate, slow commands
- **Kafka**: Broker down, under-replicated partitions, consumer lag
- **Kubernetes**: Pod crashes, replicas mismatch, PVC full, CPU throttling

### SLO Alerts (`slo-alerts.yaml`)
- Availability burn rate (fast/slow)
- Latency P95/P99 thresholds
- Error budget tracking

## Grafana Dashboards

### QAWave Overview
- Service health status
- Request rate and latency
- Error rate
- Resource usage by pod

### QAWave Backend
- JVM metrics (heap, threads, GC)
- HTTP metrics by endpoint
- Database connection pool

### QAWave Infrastructure
- PostgreSQL: connections, transactions, size
- Redis: memory, clients, cache hit rate
- Kafka: partitions, lag, message rate

## Test Plan

- [ ] Apply alerting rules
- [ ] Verify alerts appear in Prometheus
- [ ] Import dashboards to Grafana
- [ ] Verify metrics are displayed

Closes #196, #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)