### PR TITLE
[Database] feat: add PostgreSQL Grafana dashboard (#196)

### DIFF
--- a/infrastructure/kubernetes/base/monitoring/grafana/dashboards/README.md
+++ b/infrastructure/kubernetes/base/monitoring/grafana/dashboards/README.md
@@ -1,0 +1,118 @@
+# Grafana Dashboards
+
+Pre-configured Grafana dashboards for QAWave monitoring.
+
+## Available Dashboards
+
+### PostgreSQL Performance (`postgresql-performance.json`)
+
+Comprehensive PostgreSQL monitoring dashboard with:
+
+**Overview Panels:**
+- Connection usage percentage
+- Active connections count
+- Database size
+- Total deadlocks
+- Transaction rate (commits/rollbacks)
+
+**Query Performance:**
+- Row operations rate (fetch, insert, update, delete)
+- Buffer cache hit ratio (target: >99%)
+
+**Table Statistics:**
+- Row count by table (qa_packages, test_scenarios, test_runs, test_step_results)
+- Table scan types (sequential vs index scans)
+
+**Index Performance:**
+- Top 10 most used indexes
+- Least used indexes (candidates for removal)
+
+**Replication & WAL:**
+- Buffer writes rate
+- Checkpoint statistics
+
+## Prerequisites
+
+1. PostgreSQL exporter (postgres_exporter) deployed
+2. Prometheus scraping PostgreSQL metrics
+3. Grafana with Prometheus data source configured
+
+## Installation
+
+### Using Kubernetes ConfigMap
+
+```bash
+kubectl create configmap grafana-dashboards \
+  --from-file=postgresql-performance.json \
+  -n monitoring
+```
+
+### Using Grafana Provisioning
+
+Add to `grafana.ini`:
+```ini
+[dashboards]
+provisioning_path = /etc/grafana/provisioning/dashboards
+```
+
+Mount the dashboard files to `/etc/grafana/provisioning/dashboards/`.
+
+### Manual Import
+
+1. Open Grafana UI
+2. Go to Dashboards → Import
+3. Upload the JSON file or paste contents
+4. Select Prometheus data source
+5. Save
+
+## Key Metrics to Watch
+
+| Metric | Healthy Range | Action if Unhealthy |
+|--------|--------------|---------------------|
+| Connection Usage | < 80% | Increase max_connections or add connection pooling |
+| Cache Hit Ratio | > 99% | Increase shared_buffers |
+| Sequential Scans | Low on large tables | Add missing indexes |
+| Deadlocks | 0 | Review transaction ordering |
+
+## Customization
+
+### Adding Application-Specific Queries
+
+```promql
+# QA Package execution time
+histogram_quantile(0.95, rate(qa_package_duration_seconds_bucket[5m]))
+
+# Active test runs
+pg_stat_user_tables_n_live_tup{relname="test_runs"} - pg_stat_user_tables_n_dead_tup{relname="test_runs"}
+```
+
+### Alerting Rules
+
+Recommended alerts (add to Prometheus):
+
+```yaml
+groups:
+  - name: postgresql
+    rules:
+      - alert: PostgreSQLHighConnectionUsage
+        expr: (pg_stat_activity_count / pg_settings_max_connections) * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL connection usage is high"
+
+      - alert: PostgreSQLLowCacheHitRatio
+        expr: (pg_stat_database_blks_hit / (pg_stat_database_blks_hit + pg_stat_database_blks_read)) * 100 < 95
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL cache hit ratio is low"
+```
+
+## Related Documentation
+
+- [PostgreSQL Exporter](https://github.com/prometheus-community/postgres_exporter)
+- [ServiceMonitor Configuration](../servicemonitors/postgresql-servicemonitor.yaml)
+- [Backup Monitoring](../../../data-services/postgresql/backup/README.md)

--- a/infrastructure/kubernetes/base/monitoring/grafana/dashboards/kustomization.yaml
+++ b/infrastructure/kubernetes/base/monitoring/grafana/dashboards/kustomization.yaml
@@ -1,0 +1,18 @@
+# Grafana Dashboard ConfigMaps
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+configMapGenerator:
+  - name: grafana-dashboard-postgresql
+    files:
+      - postgresql-performance.json
+    options:
+      labels:
+        grafana_dashboard: "1"
+
+commonLabels:
+  app.kubernetes.io/name: grafana
+  app.kubernetes.io/component: dashboards
+  app.kubernetes.io/part-of: qawave-monitoring

--- a/infrastructure/kubernetes/base/monitoring/grafana/dashboards/postgresql-performance.json
+++ b/infrastructure/kubernetes/base/monitoring/grafana/dashboards/postgresql-performance.json
@@ -1,0 +1,548 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "PostgreSQL performance monitoring for QAWave",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Database Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 80 },
+              { "color": "red", "value": 95 }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "(pg_stat_activity_count{datname=\"qawave\"} / pg_settings_max_connections) * 100",
+          "legendFormat": "Connection Usage",
+          "refId": "A"
+        }
+      ],
+      "title": "Connection Usage %",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{datname=\"qawave\"}",
+          "legendFormat": "Active Connections",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Connections",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pg_database_size_bytes{datname=\"qawave\"}",
+          "legendFormat": "Database Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Database Size",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_database_deadlocks{datname=\"qawave\"}",
+          "legendFormat": "Deadlocks",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Deadlocks",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_database_xact_commit{datname=\"qawave\"}[5m])",
+          "legendFormat": "Commits/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(pg_stat_database_xact_rollback{datname=\"qawave\"}[5m])",
+          "legendFormat": "Rollbacks/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Transaction Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "panels": [],
+      "title": "Query Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_database_tup_fetched{datname=\"qawave\"}[5m])",
+          "legendFormat": "Rows Fetched/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(pg_stat_database_tup_inserted{datname=\"qawave\"}[5m])",
+          "legendFormat": "Rows Inserted/s",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(pg_stat_database_tup_updated{datname=\"qawave\"}[5m])",
+          "legendFormat": "Rows Updated/s",
+          "refId": "C"
+        },
+        {
+          "expr": "rate(pg_stat_database_tup_deleted{datname=\"qawave\"}[5m])",
+          "legendFormat": "Rows Deleted/s",
+          "refId": "D"
+        }
+      ],
+      "title": "Row Operations Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "percent"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "(pg_stat_database_blks_hit{datname=\"qawave\"} / (pg_stat_database_blks_hit{datname=\"qawave\"} + pg_stat_database_blks_read{datname=\"qawave\"})) * 100",
+          "legendFormat": "Cache Hit Ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Buffer Cache Hit Ratio",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 102,
+      "panels": [],
+      "title": "Table Statistics",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_user_tables_n_live_tup{relname=~\"qa_packages|test_scenarios|test_runs|test_step_results\"}",
+          "legendFormat": "{{ relname }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Row Count by Table",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_user_tables_seq_scan{relname=~\"qa_packages|test_scenarios|test_runs\"}[5m])",
+          "legendFormat": "{{ relname }} - Seq Scans/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(pg_stat_user_tables_idx_scan{relname=~\"qa_packages|test_scenarios|test_runs\"}[5m])",
+          "legendFormat": "{{ relname }} - Idx Scans/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Table Scan Types",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "panels": [],
+      "title": "Index Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
+      "id": 10,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "topk(10, pg_stat_user_indexes_idx_scan)",
+          "legendFormat": "{{ indexrelname }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Most Used Indexes",
+      "type": "bargauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "green", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 28 },
+      "id": 11,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "bottomk(10, pg_stat_user_indexes_idx_scan > 0)",
+          "legendFormat": "{{ indexrelname }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Least Used Indexes (Review for Removal)",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "id": 104,
+      "panels": [],
+      "title": "Replication & WAL",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "rate(pg_stat_bgwriter_buffers_checkpoint[5m]) * 8192",
+          "legendFormat": "Checkpoint Buffers/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(pg_stat_bgwriter_buffers_backend[5m]) * 8192",
+          "legendFormat": "Backend Buffers/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Buffer Writes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "pg_stat_bgwriter_checkpoints_timed + pg_stat_bgwriter_checkpoints_req",
+          "legendFormat": "Total Checkpoints",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Checkpoints",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": ["postgresql", "database", "qawave"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "QAWave - PostgreSQL Performance",
+  "uid": "qawave-postgresql",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
Adds comprehensive PostgreSQL performance monitoring dashboard for Grafana as part of the Grafana dashboards setup (issue #196).

## Dashboard Panels

### Overview Section
| Panel | Metric | Purpose |
|-------|--------|---------|
| Connection Usage % | Active / Max | Monitor connection pool saturation |
| Active Connections | Count | Current load indicator |
| Database Size | Bytes | Track data growth |
| Total Deadlocks | Count | Concurrency issues |
| Transaction Rate | Commits/Rollbacks per second | Throughput monitoring |

### Query Performance
- **Row Operations Rate**: Fetched, inserted, updated, deleted rows/s
- **Buffer Cache Hit Ratio**: Target >99% for optimal performance

### Table Statistics
- Row counts for: `qa_packages`, `test_scenarios`, `test_runs`, `test_step_results`
- Sequential vs Index scan rates (identify missing indexes)

### Index Performance
- Top 10 most used indexes
- Least used indexes (candidates for cleanup)

### WAL & Checkpoints
- Buffer writes rate
- Total checkpoints

## Files Added
- `grafana/dashboards/postgresql-performance.json` - Dashboard definition
- `grafana/dashboards/kustomization.yaml` - ConfigMap generator
- `grafana/dashboards/README.md` - Installation guide

## Installation

```bash
# Using Kustomize
kubectl apply -k infrastructure/kubernetes/base/monitoring/grafana/dashboards/

# Or import JSON directly in Grafana UI
```

## Key Metrics to Monitor

| Metric | Healthy | Warning | Critical |
|--------|---------|---------|----------|
| Connection Usage | <70% | 70-85% | >85% |
| Cache Hit Ratio | >99% | 95-99% | <95% |
| Deadlocks | 0 | 1-5 | >5 |

## Supports #196 Acceptance Criteria
- [x] Database performance dashboard

Refs: #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)