### PR TITLE
[Backend] feat: add request logging and tracing (#199)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -67,6 +67,14 @@ dependencies {
     // Observability
     implementation("io.micrometer:micrometer-registry-prometheus")
 
+    // Structured Logging (JSON)
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+
+    // OpenTelemetry for distributed tracing
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+    runtimeOnly("io.opentelemetry:opentelemetry-exporter-zipkin")
+
     // Security - OAuth2 Resource Server for Keycloak
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springframework.security:spring-security-oauth2-jose")

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/CorrelationIdFilter.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/CorrelationIdFilter.kt
@@ -1,0 +1,87 @@
+package com.qawave.infrastructure.logging
+
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+import java.util.UUID
+
+/**
+ * WebFilter that manages correlation IDs for request tracing.
+ *
+ * Features:
+ * - Extracts correlation ID from X-Correlation-ID header
+ * - Generates new correlation ID if not present
+ * - Propagates correlation ID to response headers
+ * - Sets correlation ID in MDC for logging
+ * - Sets correlation ID in Reactor context for reactive chains
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class CorrelationIdFilter : WebFilter {
+
+    companion object {
+        const val CORRELATION_ID_HEADER = "X-Correlation-ID"
+        const val REQUEST_ID_HEADER = "X-Request-ID"
+        const val MDC_CORRELATION_ID = "correlationId"
+        const val MDC_REQUEST_ID = "requestId"
+        const val CONTEXT_CORRELATION_ID = "correlationId"
+        const val CONTEXT_REQUEST_ID = "requestId"
+    }
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        // Extract or generate correlation ID
+        val correlationId = exchange.request.headers.getFirst(CORRELATION_ID_HEADER)
+            ?: UUID.randomUUID().toString()
+
+        // Generate unique request ID for this specific request
+        val requestId = exchange.request.headers.getFirst(REQUEST_ID_HEADER)
+            ?: UUID.randomUUID().toString()
+
+        // Add IDs to response headers
+        exchange.response.headers.add(CORRELATION_ID_HEADER, correlationId)
+        exchange.response.headers.add(REQUEST_ID_HEADER, requestId)
+
+        // Store in exchange attributes for access in other filters
+        exchange.attributes[CONTEXT_CORRELATION_ID] = correlationId
+        exchange.attributes[CONTEXT_REQUEST_ID] = requestId
+
+        return chain.filter(exchange)
+            .contextWrite { context ->
+                context
+                    .put(CONTEXT_CORRELATION_ID, correlationId)
+                    .put(CONTEXT_REQUEST_ID, requestId)
+            }
+            .doFirst {
+                MDC.put(MDC_CORRELATION_ID, correlationId)
+                MDC.put(MDC_REQUEST_ID, requestId)
+            }
+            .doFinally {
+                MDC.remove(MDC_CORRELATION_ID)
+                MDC.remove(MDC_REQUEST_ID)
+            }
+    }
+}
+
+/**
+ * Utility object for accessing correlation IDs in reactive chains.
+ */
+object CorrelationContext {
+    /**
+     * Gets the correlation ID from the Reactor context.
+     */
+    fun getCorrelationId(): Mono<String> = Mono.deferContextual { ctx ->
+        Mono.justOrEmpty(ctx.getOrDefault<String?>(CorrelationIdFilter.CONTEXT_CORRELATION_ID, null))
+    }
+
+    /**
+     * Gets the request ID from the Reactor context.
+     */
+    fun getRequestId(): Mono<String> = Mono.deferContextual { ctx ->
+        Mono.justOrEmpty(ctx.getOrDefault<String?>(CorrelationIdFilter.CONTEXT_REQUEST_ID, null))
+    }
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/LoggingConfig.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/LoggingConfig.kt
@@ -1,0 +1,51 @@
+package com.qawave.infrastructure.logging
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for logging and tracing.
+ */
+@ConfigurationProperties(prefix = "qawave.logging")
+data class LoggingConfig(
+    /** Enable request/response logging. */
+    val requestLogging: RequestLoggingConfig = RequestLoggingConfig(),
+    /** Headers to redact from logs. */
+    val redactedHeaders: List<String> = listOf(
+        "Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "X-API-Key",
+        "X-Auth-Token",
+    ),
+    /** JSON fields to redact from request/response bodies. */
+    val redactedFields: List<String> = listOf(
+        "password",
+        "secret",
+        "token",
+        "apiKey",
+        "api_key",
+        "credentials",
+        "credit_card",
+        "creditCard",
+        "ssn",
+    ),
+)
+
+data class RequestLoggingConfig(
+    /** Enable request logging. */
+    val enabled: Boolean = true,
+    /** Log request body. */
+    val logRequestBody: Boolean = false,
+    /** Log response body. */
+    val logResponseBody: Boolean = false,
+    /** Maximum body size to log (bytes). */
+    val maxBodySize: Int = 4096,
+    /** Paths to exclude from logging. */
+    val excludedPaths: List<String> = listOf(
+        "/actuator",
+        "/health",
+        "/ready",
+        "/api-docs",
+        "/swagger-ui",
+    ),
+)

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/RequestLoggingFilter.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/RequestLoggingFilter.kt
@@ -1,0 +1,162 @@
+package com.qawave.infrastructure.logging
+
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.http.server.reactive.ServerHttpRequest
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ServerWebExchange
+import org.springframework.web.server.WebFilter
+import org.springframework.web.server.WebFilterChain
+import reactor.core.publisher.Mono
+
+/**
+ * WebFilter that logs structured request/response information.
+ *
+ * Features:
+ * - Structured JSON logging with request metadata
+ * - Request timing measurement
+ * - Sensitive header redaction
+ * - Path-based exclusion
+ * - MDC context with trace information
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1) // After CorrelationIdFilter
+@ConditionalOnProperty(
+    name = ["qawave.logging.request-logging.enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class RequestLoggingFilter(
+    private val loggingConfig: LoggingConfig,
+    private val sensitiveDataRedactor: SensitiveDataRedactor,
+) : WebFilter {
+    private val logger = LoggerFactory.getLogger(RequestLoggingFilter::class.java)
+
+    override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
+        val path = exchange.request.path.value()
+
+        // Skip excluded paths
+        if (isExcludedPath(path)) {
+            return chain.filter(exchange)
+        }
+
+        val startTime = System.currentTimeMillis()
+        val request = exchange.request
+
+        // Set MDC values for structured logging
+        setRequestMdc(request)
+
+        // Log incoming request
+        logRequest(request)
+
+        return chain.filter(exchange)
+            .doOnSuccess {
+                logResponse(exchange, startTime)
+            }
+            .doOnError { error ->
+                logError(exchange, startTime, error)
+            }
+            .doFinally {
+                clearRequestMdc()
+            }
+    }
+
+    private fun setRequestMdc(request: ServerHttpRequest) {
+        MDC.put("http.method", request.method.name())
+        MDC.put("http.path", request.path.value())
+        MDC.put("http.query", request.uri.query ?: "")
+        MDC.put("client.ip", request.remoteAddress?.address?.hostAddress ?: "unknown")
+        MDC.put("http.userAgent", request.headers.getFirst("User-Agent") ?: "unknown")
+    }
+
+    private fun clearRequestMdc() {
+        MDC.remove("http.method")
+        MDC.remove("http.path")
+        MDC.remove("http.query")
+        MDC.remove("http.status")
+        MDC.remove("http.duration")
+        MDC.remove("client.ip")
+        MDC.remove("http.userAgent")
+    }
+
+    private fun logRequest(request: ServerHttpRequest) {
+        val headers = redactHeaders(request.headers.toSingleValueMap())
+
+        logger.info(
+            "Incoming request: {} {} from {}",
+            request.method.name(),
+            request.path.value(),
+            request.remoteAddress?.address?.hostAddress ?: "unknown",
+        )
+
+        if (logger.isDebugEnabled) {
+            logger.debug("Request headers: {}", headers)
+        }
+    }
+
+    private fun logResponse(exchange: ServerWebExchange, startTime: Long) {
+        val duration = System.currentTimeMillis() - startTime
+        val statusCode = exchange.response.statusCode?.value() ?: 0
+
+        MDC.put("http.status", statusCode.toString())
+        MDC.put("http.duration", duration.toString())
+
+        if (statusCode >= 400) {
+            logger.warn(
+                "Request completed: {} {} - {} in {}ms",
+                exchange.request.method.name(),
+                exchange.request.path.value(),
+                statusCode,
+                duration,
+            )
+        } else {
+            logger.info(
+                "Request completed: {} {} - {} in {}ms",
+                exchange.request.method.name(),
+                exchange.request.path.value(),
+                statusCode,
+                duration,
+            )
+        }
+    }
+
+    private fun logError(exchange: ServerWebExchange, startTime: Long, error: Throwable) {
+        val duration = System.currentTimeMillis() - startTime
+
+        MDC.put("http.status", "500")
+        MDC.put("http.duration", duration.toString())
+        MDC.put("error.type", error.javaClass.simpleName)
+        MDC.put("error.message", error.message ?: "")
+
+        logger.error(
+            "Request failed: {} {} - {} in {}ms",
+            exchange.request.method.name(),
+            exchange.request.path.value(),
+            error.javaClass.simpleName,
+            duration,
+            error,
+        )
+
+        MDC.remove("error.type")
+        MDC.remove("error.message")
+    }
+
+    private fun redactHeaders(headers: Map<String, String>): Map<String, String> {
+        return headers.mapValues { (key, value) ->
+            if (sensitiveDataRedactor.isSensitiveHeader(key)) {
+                "[REDACTED]"
+            } else {
+                value
+            }
+        }
+    }
+
+    private fun isExcludedPath(path: String): Boolean {
+        return loggingConfig.requestLogging.excludedPaths.any { excluded ->
+            path.startsWith(excluded)
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/SensitiveDataRedactor.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/SensitiveDataRedactor.kt
@@ -1,0 +1,126 @@
+package com.qawave.infrastructure.logging
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.springframework.stereotype.Component
+
+/**
+ * Service for redacting sensitive data from logs.
+ *
+ * Features:
+ * - Header redaction for sensitive headers
+ * - JSON field redaction for request/response bodies
+ * - Configurable patterns for sensitive data
+ */
+@Component
+class SensitiveDataRedactor(
+    private val loggingConfig: LoggingConfig,
+    private val objectMapper: ObjectMapper,
+) {
+    companion object {
+        const val REDACTED = "[REDACTED]"
+
+        // Common patterns for sensitive data
+        private val SENSITIVE_PATTERNS = listOf(
+            Regex("(?i)password"),
+            Regex("(?i)secret"),
+            Regex("(?i)token"),
+            Regex("(?i)api[-_]?key"),
+            Regex("(?i)auth"),
+            Regex("(?i)credential"),
+            Regex("(?i)bearer"),
+        )
+    }
+
+    /**
+     * Checks if a header name is sensitive and should be redacted.
+     */
+    fun isSensitiveHeader(headerName: String): Boolean {
+        val lowerName = headerName.lowercase()
+        return loggingConfig.redactedHeaders.any { it.lowercase() == lowerName } ||
+            SENSITIVE_PATTERNS.any { it.containsMatchIn(lowerName) }
+    }
+
+    /**
+     * Checks if a JSON field name is sensitive and should be redacted.
+     */
+    fun isSensitiveField(fieldName: String): Boolean {
+        val lowerName = fieldName.lowercase()
+        return loggingConfig.redactedFields.any { it.lowercase() == lowerName } ||
+            SENSITIVE_PATTERNS.any { it.containsMatchIn(lowerName) }
+    }
+
+    /**
+     * Redacts sensitive fields from a JSON string.
+     *
+     * @param json The JSON string to redact
+     * @return Redacted JSON string, or original if parsing fails
+     */
+    fun redactJson(json: String): String {
+        return try {
+            val node = objectMapper.readTree(json)
+            val redacted = redactNode(node)
+            objectMapper.writeValueAsString(redacted)
+        } catch (_: Exception) {
+            // If JSON parsing fails, mask any obvious sensitive patterns
+            redactPlainText(json)
+        }
+    }
+
+    /**
+     * Recursively redacts sensitive fields in a JSON node.
+     */
+    private fun redactNode(node: JsonNode): JsonNode {
+        return when {
+            node.isObject -> {
+                val objectNode = node.deepCopy<ObjectNode>()
+                val iterator = objectNode.fields()
+                while (iterator.hasNext()) {
+                    val (name, value) = iterator.next()
+                    if (isSensitiveField(name)) {
+                        objectNode.put(name, REDACTED)
+                    } else {
+                        objectNode.set<JsonNode>(name, redactNode(value))
+                    }
+                }
+                objectNode
+            }
+            node.isArray -> {
+                val arrayNode = objectMapper.createArrayNode()
+                node.forEach { element ->
+                    arrayNode.add(redactNode(element))
+                }
+                arrayNode
+            }
+            else -> node
+        }
+    }
+
+    /**
+     * Redacts sensitive patterns from plain text.
+     */
+    fun redactPlainText(text: String): String {
+        var result = text
+
+        // Redact potential bearer tokens
+        result = result.replace(Regex("Bearer\\s+[A-Za-z0-9\\-_.]+"), "Bearer $REDACTED")
+
+        // Redact potential API keys (common patterns)
+        result = result.replace(
+            Regex("(?i)(api[-_]?key|apikey|secret|password|token)\\s*[=:]\\s*[\"']?[^\"'\\s,}]+"),
+            "$1=$REDACTED",
+        )
+
+        return result
+    }
+
+    /**
+     * Redacts a map of headers.
+     */
+    fun redactHeaders(headers: Map<String, String>): Map<String, String> {
+        return headers.mapValues { (key, value) ->
+            if (isSensitiveHeader(key)) REDACTED else value
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/StructuredLogger.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/StructuredLogger.kt
@@ -1,0 +1,136 @@
+package com.qawave.infrastructure.logging
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+
+/**
+ * Utility class for structured logging with additional context.
+ *
+ * Usage:
+ * ```kotlin
+ * class MyService {
+ *     private val logger = StructuredLogger.getLogger<MyService>()
+ *
+ *     fun process() {
+ *         logger.withContext("userId" to "123", "action" to "process") {
+ *             info("Processing started")
+ *         }
+ *     }
+ * }
+ * ```
+ */
+class StructuredLogger(@PublishedApi internal val delegate: Logger) : Logger by delegate {
+
+    companion object {
+        inline fun <reified T> getLogger(): StructuredLogger {
+            return StructuredLogger(LoggerFactory.getLogger(T::class.java))
+        }
+
+        fun getLogger(name: String): StructuredLogger {
+            return StructuredLogger(LoggerFactory.getLogger(name))
+        }
+
+        fun getLogger(clazz: Class<*>): StructuredLogger {
+            return StructuredLogger(LoggerFactory.getLogger(clazz))
+        }
+    }
+
+    /**
+     * Executes a block with additional MDC context.
+     * Context is automatically cleaned up after the block executes.
+     */
+    inline fun <T> withContext(vararg context: Pair<String, String?>, block: Logger.() -> T): T {
+        val previousValues = mutableMapOf<String, String?>()
+
+        try {
+            // Store previous values and set new context
+            context.forEach { (key, value) ->
+                previousValues[key] = MDC.get(key)
+                if (value != null) {
+                    MDC.put(key, value)
+                } else {
+                    MDC.remove(key)
+                }
+            }
+
+            return block(delegate)
+        } finally {
+            // Restore previous values
+            previousValues.forEach { (key, value) ->
+                if (value != null) {
+                    MDC.put(key, value)
+                } else {
+                    MDC.remove(key)
+                }
+            }
+        }
+    }
+
+    /**
+     * Logs a message with additional structured context.
+     */
+    fun infoWithContext(message: String, vararg context: Pair<String, String?>) {
+        withContext(*context) {
+            info(message)
+        }
+    }
+
+    /**
+     * Logs a warning with additional structured context.
+     */
+    fun warnWithContext(message: String, vararg context: Pair<String, String?>) {
+        withContext(*context) {
+            warn(message)
+        }
+    }
+
+    /**
+     * Logs an error with additional structured context.
+     */
+    fun errorWithContext(message: String, throwable: Throwable? = null, vararg context: Pair<String, String?>) {
+        withContext(*context) {
+            if (throwable != null) {
+                error(message, throwable)
+            } else {
+                error(message)
+            }
+        }
+    }
+
+    /**
+     * Logs a debug message with additional structured context.
+     */
+    fun debugWithContext(message: String, vararg context: Pair<String, String?>) {
+        withContext(*context) {
+            debug(message)
+        }
+    }
+}
+
+/**
+ * Extension function to add context to any logger operation.
+ */
+inline fun <T> Logger.withMdcContext(vararg context: Pair<String, String?>, block: Logger.() -> T): T {
+    val previousValues = mutableMapOf<String, String?>()
+
+    try {
+        context.forEach { (key, value) ->
+            previousValues[key] = MDC.get(key)
+            if (value != null) {
+                MDC.put(key, value)
+            } else {
+                MDC.remove(key)
+            }
+        }
+        return block()
+    } finally {
+        previousValues.forEach { (key, value) ->
+            if (value != null) {
+                MDC.put(key, value)
+            } else {
+                MDC.remove(key)
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/logging/TracingConfig.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/logging/TracingConfig.kt
@@ -1,0 +1,32 @@
+package com.qawave.infrastructure.logging
+
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.aop.ObservedAspect
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Configuration for distributed tracing with OpenTelemetry.
+ *
+ * Features:
+ * - Micrometer Observation integration
+ * - Trace context propagation
+ * - Custom spans for key operations
+ */
+@Configuration
+@ConditionalOnProperty(
+    name = ["qawave.tracing.enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class TracingConfig {
+
+    /**
+     * Enables @Observed annotation support for creating custom spans.
+     */
+    @Bean
+    fun observedAspect(observationRegistry: ObservationRegistry): ObservedAspect {
+        return ObservedAspect(observationRegistry)
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -92,6 +92,33 @@ qawave:
     enabled: ${RATE_LIMIT_ENABLED:true}
     default-limit: 1000
     default-window-seconds: 60
+  logging:
+    request-logging:
+      enabled: ${REQUEST_LOGGING_ENABLED:true}
+      log-request-body: ${LOG_REQUEST_BODY:false}
+      log-response-body: ${LOG_RESPONSE_BODY:false}
+      max-body-size: 4096
+      excluded-paths:
+        - /actuator
+        - /health
+        - /ready
+        - /api-docs
+        - /swagger-ui
+    redacted-headers:
+      - Authorization
+      - Cookie
+      - Set-Cookie
+      - X-API-Key
+      - X-Auth-Token
+    redacted-fields:
+      - password
+      - secret
+      - token
+      - apiKey
+      - api_key
+      - credentials
+  tracing:
+    enabled: ${TRACING_ENABLED:true}
 
 management:
   endpoints:
@@ -104,6 +131,12 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+  tracing:
+    sampling:
+      probability: ${TRACING_SAMPLE_RATE:1.0}
+  otlp:
+    tracing:
+      endpoint: ${OTLP_ENDPOINT:http://localhost:4318/v1/traces}
 
 server:
   port: 8080

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <!-- Default Spring Boot base configuration -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- Properties from application.yml -->
+    <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="qawave"/>
+    <springProperty scope="context" name="logLevel" source="logging.level.root" defaultValue="INFO"/>
+
+    <!-- Console appender for development (human-readable) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(%5p) %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} [%X{correlationId:-}] [%X{requestId:-}] %m%n%wEx</pattern>
+        </encoder>
+    </appender>
+
+    <!-- JSON appender for production (structured logging) -->
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <!-- Include timestamp, level, logger, message -->
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampPattern>
+
+            <!-- Add application name -->
+            <customFields>{"application":"${appName}"}</customFields>
+
+            <!-- Include MDC fields -->
+            <includeMdcKeyName>correlationId</includeMdcKeyName>
+            <includeMdcKeyName>requestId</includeMdcKeyName>
+            <includeMdcKeyName>http.method</includeMdcKeyName>
+            <includeMdcKeyName>http.path</includeMdcKeyName>
+            <includeMdcKeyName>http.status</includeMdcKeyName>
+            <includeMdcKeyName>http.duration</includeMdcKeyName>
+            <includeMdcKeyName>client.ip</includeMdcKeyName>
+            <includeMdcKeyName>userId</includeMdcKeyName>
+
+            <!-- Include trace/span IDs when available -->
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+
+            <!-- Shorten field names for efficiency -->
+            <fieldNames>
+                <timestamp>@timestamp</timestamp>
+                <version>[ignore]</version>
+                <levelValue>[ignore]</levelValue>
+            </fieldNames>
+
+            <!-- Include exception stack traces -->
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>4096</maxLength>
+                <shortenedClassNameLength>20</shortenedClassNameLength>
+                <exclude>^sun\.reflect\..*\.invoke</exclude>
+                <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+        </encoder>
+    </appender>
+
+    <!-- File appender for persistent logs -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/${appName}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/${appName}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSSZ</timestampPattern>
+            <customFields>{"application":"${appName}"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- Async wrapper for file appender to improve performance -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>false</includeCallerData>
+    </appender>
+
+    <!-- Development profile: human-readable console output -->
+    <springProfile name="default,local,dev">
+        <root level="${logLevel}">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <!-- QAWave application logs -->
+        <logger name="com.qawave" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
+    <!-- Test profile: minimal logging -->
+    <springProfile name="test">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="com.qawave" level="DEBUG" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
+
+    <!-- Production profile: JSON structured logging -->
+    <springProfile name="prod,production,staging">
+        <root level="${logLevel}">
+            <appender-ref ref="JSON"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </root>
+
+        <logger name="com.qawave" level="INFO" additivity="false">
+            <appender-ref ref="JSON"/>
+            <appender-ref ref="ASYNC_FILE"/>
+        </logger>
+
+        <!-- Reduce noise from frameworks -->
+        <logger name="org.springframework" level="WARN"/>
+        <logger name="io.netty" level="WARN"/>
+        <logger name="reactor" level="WARN"/>
+        <logger name="io.lettuce" level="WARN"/>
+    </springProfile>
+
+</configuration>

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -26,6 +26,11 @@ management:
 qawave:
   security:
     enabled: false
+  logging:
+    request-logging:
+      enabled: false
+  tracing:
+    enabled: false
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- Add structured JSON logging for production environments
- Add correlation ID propagation across requests
- Add OpenTelemetry/Micrometer distributed tracing integration
- Add sensitive data redaction for logs
- Add configurable request/response logging

## Changes

### New Files
- `LoggingConfig.kt` - Configuration properties for logging settings
- `CorrelationIdFilter.kt` - WebFilter for correlation ID propagation
- `RequestLoggingFilter.kt` - Structured request/response logging
- `SensitiveDataRedactor.kt` - Redacts sensitive headers and JSON fields
- `TracingConfig.kt` - OpenTelemetry tracing configuration
- `StructuredLogger.kt` - Utility for context-aware structured logging
- `logback-spring.xml` - Logback configuration with JSON output

### Modified Files
- `build.gradle.kts` - Added logging and tracing dependencies
- `application.yml` - Added logging and tracing configuration
- `application-test.yml` - Disabled request logging in tests
- `QaWaveApplication.kt` - Added @ConfigurationPropertiesScan

## Features
- **Structured Logging**: JSON format for production with Logstash encoder
- **Correlation IDs**: X-Correlation-ID header propagation and generation
- **Request Logging**: Method, path, status, duration with MDC context
- **Sensitive Data Redaction**: Configurable header and field redaction
- **Distributed Tracing**: OpenTelemetry integration with OTLP export
- **Profile-based Config**: Human-readable logs in dev, JSON in production

## Configuration
```yaml
qawave:
  logging:
    request-logging:
      enabled: true
      excluded-paths: [/actuator, /health]
    redacted-headers: [Authorization, Cookie]
    redacted-fields: [password, token, secret]
  tracing:
    enabled: true

management:
  tracing:
    sampling:
      probability: 1.0
  otlp:
    tracing:
      endpoint: http://localhost:4318/v1/traces
```

## Test plan
- [x] Unit tests pass
- [x] Application context loads
- [x] Health endpoints work
- [ ] Verify correlation ID headers in responses
- [ ] Verify JSON log output in production profile
- [ ] Verify trace propagation to OTLP endpoint

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)