### PR TITLE
[Frontend] fix: run links navigate to run detail page (#304)

### DIFF
--- a/frontend/src/routes/_app/packages.$packageId.tsx
+++ b/frontend/src/routes/_app/packages.$packageId.tsx
@@ -152,7 +152,7 @@ function PackageDetailPage() {
         <ScenariosTab scenarios={scenarios?.content ?? []} isLoading={scenariosLoading} />
       )}
       {activeTab === 'runs' && (
-        <RunsTab runs={runs?.content ?? []} isLoading={runsLoading} packageId={packageId} />
+        <RunsTab runs={runs?.content ?? []} isLoading={runsLoading} />
       )}
       {activeTab === 'coverage' && (
         <CoverageTab scenarios={scenarios?.content ?? []} isLoading={scenariosLoading} />
@@ -226,11 +226,9 @@ function ScenarioCard({ scenario }: { scenario: Scenario }) {
 function RunsTab({
   runs,
   isLoading,
-  packageId,
 }: {
   runs: TestRun[]
   isLoading: boolean
-  packageId: string
 }) {
   if (isLoading) {
     return (
@@ -270,13 +268,13 @@ function RunsTab({
   return (
     <div className="space-y-3">
       {runs.map((run) => (
-        <RunCard key={run.id} run={run} packageId={packageId} />
+        <RunCard key={run.id} run={run} />
       ))}
     </div>
   )
 }
 
-function RunCard({ run, packageId }: { run: TestRun; packageId: string }) {
+function RunCard({ run }: { run: TestRun }) {
   const statusColors: Record<string, string> = {
     PENDING: 'bg-yellow-500/10 text-yellow-500',
     RUNNING: 'bg-blue-500/10 text-blue-500',
@@ -286,8 +284,8 @@ function RunCard({ run, packageId }: { run: TestRun; packageId: string }) {
 
   return (
     <Link
-      to="/packages/$packageId"
-      params={{ packageId }}
+      to="/runs/$runId"
+      params={{ runId: run.id }}
       className="card block hover:border-primary-500 transition-colors"
     >
       <div className="flex justify-between items-start">


### PR DESCRIPTION
## Summary

- Fix RunCard in package detail page to link to `/runs/:runId` instead of staying on package page
- Remove unused `packageId` prop from `RunsTab` and `RunCard` components

## Background

The RunCard was incorrectly linking back to the same package page. Now it correctly navigates to the run detail page.

**Note:** Scenario links require PR #301 (Scenario Detail Page) to be merged first. A follow-up PR will add scenario links after that.

## Test plan

- [ ] Navigate to a package detail page
- [ ] Switch to the "Test Runs" tab
- [ ] Click on a run card
- [ ] Verify navigation goes to `/runs/:runId` (run detail page)

Partially addresses #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)