### PR TITLE
[Frontend] feat: add settings tab to package detail page (#306)

### DIFF
--- a/frontend/src/hooks/usePackages.ts
+++ b/frontend/src/hooks/usePackages.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { packagesApi } from '@/api'
-import type { CreateQaPackageRequest } from '@/api/types'
+import type { CreateQaPackageRequest, UpdateQaPackageRequest } from '@/api/types'
 
 // Query key factory
 export const packageKeys = {
@@ -45,6 +45,19 @@ export function useDeletePackage() {
   return useMutation({
     mutationFn: (id: string) => packagesApi.delete(id),
     onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: packageKeys.lists() })
+    },
+  })
+}
+
+export function useUpdatePackage() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateQaPackageRequest }) =>
+      packagesApi.update(id, data),
+    onSuccess: (_data, { id }) => {
+      void queryClient.invalidateQueries({ queryKey: packageKeys.detail(id) })
       void queryClient.invalidateQueries({ queryKey: packageKeys.lists() })
     },
   })


### PR DESCRIPTION
## Summary
- Add Settings tab to package detail page with editable fields for package configuration
- Add useUpdatePackage hook for updating packages
- Implement delete package with type-to-confirm modal
- Fix RunCard to link to /runs/:runId (from PR #305, consolidated here)

## Features

### Settings Tab
- **General Information**: Edit package name and description
- **API Configuration**: Edit OpenAPI spec URL and base URL
- **Danger Zone**: Delete package with type-to-confirm safety pattern

### Form Behavior
- Unsaved changes detection
- Cancel/Save buttons appear when changes made
- Loading states during save
- Success/error feedback messages

### Delete Confirmation
- Modal with clear warning
- Lists what will be deleted (scenarios, run history, coverage data)
- Type package name to confirm
- Prevents accidental deletion

## Test plan
- [ ] Navigate to package detail page
- [ ] Click Settings tab
- [ ] Edit package name and description
- [ ] Verify Save/Cancel buttons appear
- [ ] Save changes and verify success message
- [ ] Cancel changes and verify form resets
- [ ] Click Delete Package button
- [ ] Verify modal appears with confirmation
- [ ] Type package name to enable delete button
- [ ] Verify run links navigate to /runs/:runId

## Technical Notes
- Added `useUpdatePackage` hook to `usePackages.ts`
- Reuses existing `useDeletePackage` hook
- TabButton component for consistent tab styling
- Form state managed with React useState

🤖 Generated with [Claude Code](https://claude.com/claude-code)