### PR TITLE
[Frontend] feat: implement per-operation coverage visualization (#321)

### DIFF
--- a/frontend/src/components/ui/OperationCoverageTable.test.tsx
+++ b/frontend/src/components/ui/OperationCoverageTable.test.tsx
@@ -1,0 +1,425 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { OperationCoverageTable } from './OperationCoverageTable'
+import type { Scenario } from '@/api/types'
+
+const createScenario = (overrides: Partial<Scenario> = {}): Scenario => ({
+  id: 'scenario-1',
+  packageId: 'pkg-1',
+  name: 'Test Scenario',
+  description: null,
+  steps: [
+    {
+      id: 'step-1',
+      order: 1,
+      method: 'GET',
+      endpoint: '/api/users',
+      headers: {},
+      body: null,
+      expectedStatus: 200,
+      assertions: [],
+      extractors: [],
+      timeoutMs: 5000,
+    },
+  ],
+  status: 'PASSED',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+const mockScenarios: Scenario[] = [
+  createScenario({
+    id: 'scenario-1',
+    name: 'Get Users',
+    status: 'PASSED',
+    steps: [
+      {
+        id: 'step-1',
+        order: 1,
+        method: 'GET',
+        endpoint: '/api/users',
+        headers: {},
+        body: null,
+        expectedStatus: 200,
+        assertions: [],
+        extractors: [],
+        timeoutMs: 5000,
+      },
+    ],
+  }),
+  createScenario({
+    id: 'scenario-2',
+    name: 'Create User',
+    status: 'PASSED',
+    steps: [
+      {
+        id: 'step-2',
+        order: 1,
+        method: 'POST',
+        endpoint: '/api/users',
+        headers: {},
+        body: '{}',
+        expectedStatus: 201,
+        assertions: [],
+        extractors: [],
+        timeoutMs: 5000,
+      },
+    ],
+  }),
+  createScenario({
+    id: 'scenario-3',
+    name: 'Delete User',
+    status: 'FAILED',
+    steps: [
+      {
+        id: 'step-3',
+        order: 1,
+        method: 'DELETE',
+        endpoint: '/api/users/{id}',
+        headers: {},
+        body: null,
+        expectedStatus: 204,
+        assertions: [],
+        extractors: [],
+        timeoutMs: 5000,
+      },
+    ],
+  }),
+  createScenario({
+    id: 'scenario-4',
+    name: 'Get Products',
+    status: 'PENDING',
+    steps: [
+      {
+        id: 'step-4',
+        order: 1,
+        method: 'GET',
+        endpoint: '/api/products',
+        headers: {},
+        body: null,
+        expectedStatus: 200,
+        assertions: [],
+        extractors: [],
+        timeoutMs: 5000,
+      },
+    ],
+  }),
+]
+
+describe('OperationCoverageTable', () => {
+  it('renders loading state', () => {
+    render(<OperationCoverageTable scenarios={[]} isLoading={true} />)
+    expect(screen.getByTestId('coverage-loading')).toBeInTheDocument()
+  })
+
+  it('renders empty state when no scenarios', () => {
+    render(<OperationCoverageTable scenarios={[]} />)
+    expect(screen.getByTestId('coverage-empty')).toBeInTheDocument()
+    expect(screen.getByText('No coverage data')).toBeInTheDocument()
+  })
+
+  it('renders coverage table with scenarios', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    expect(screen.getByTestId('coverage-table')).toBeInTheDocument()
+  })
+
+  it('displays correct coverage percentage', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    // 2 covered (GET /api/users, POST /api/users), 1 failing, 1 untested = 50% covered
+    expect(screen.getByTestId('coverage-percentage')).toHaveTextContent('50%')
+  })
+
+  it('displays correct status counts', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    expect(screen.getByTestId('covered-count')).toHaveTextContent('2')
+    expect(screen.getByTestId('failing-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('untested-count')).toHaveTextContent('1')
+  })
+
+  it('shows all operations', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    // There are 2 /api/users entries (GET and POST)
+    expect(screen.getAllByText('/api/users')).toHaveLength(2)
+    expect(screen.getByText('/api/users/{id}')).toBeInTheDocument()
+    expect(screen.getByText('/api/products')).toBeInTheDocument()
+  })
+
+  it('displays HTTP method badges', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    // There are 2 GET operations (GET /api/users and GET /api/products)
+    expect(screen.getAllByText('GET')).toHaveLength(2)
+    expect(screen.getByText('POST')).toBeInTheDocument()
+    expect(screen.getByText('DELETE')).toBeInTheDocument()
+  })
+
+  it('displays coverage status badges', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+    // "Covered" appears: 1 in stats card label + 2 in operation badges = 3
+    expect(screen.getAllByText('Covered')).toHaveLength(3)
+    // "Failing" appears: 1 in stats card label + 1 in operation badge = 2
+    expect(screen.getAllByText('Failing')).toHaveLength(2)
+    // "Untested" appears: 1 in stats card label + 1 in operation badge = 2
+    expect(screen.getAllByText('Untested')).toHaveLength(2)
+  })
+
+  it('filters by covered status', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const coveredFilter = screen.getByRole('button', { name: /covered.*2/i })
+    await user.click(coveredFilter)
+
+    // Should show only 2 covered operations
+    expect(screen.getByText('(2 of 4)')).toBeInTheDocument()
+    expect(screen.queryByText('/api/users/{id}')).not.toBeInTheDocument()
+    expect(screen.queryByText('/api/products')).not.toBeInTheDocument()
+  })
+
+  it('filters by failing status', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const failingFilter = screen.getByRole('button', { name: /failing.*1/i })
+    await user.click(failingFilter)
+
+    // Should show only failing operation
+    expect(screen.getByText('(1 of 4)')).toBeInTheDocument()
+    expect(screen.getByText('/api/users/{id}')).toBeInTheDocument()
+    expect(screen.queryByText('/api/products')).not.toBeInTheDocument()
+  })
+
+  it('filters by untested status', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const untestedFilter = screen.getByRole('button', { name: /untested.*1/i })
+    await user.click(untestedFilter)
+
+    // Should show only untested operation
+    expect(screen.getByText('(1 of 4)')).toBeInTheDocument()
+    expect(screen.getByText('/api/products')).toBeInTheDocument()
+  })
+
+  it('shows all when All filter is clicked', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    // First filter to covered
+    const coveredFilter = screen.getByRole('button', { name: /covered.*2/i })
+    await user.click(coveredFilter)
+
+    // Then click All
+    const allFilter = screen.getByRole('button', { name: /all.*4/i })
+    await user.click(allFilter)
+
+    // Should show all operations
+    expect(screen.getByText('(4 of 4)')).toBeInTheDocument()
+  })
+
+  it('shows no results message when filter has no matches', async () => {
+    const user = userEvent.setup()
+    const scenariosWithNoCovered = [
+      createScenario({
+        id: 'scenario-1',
+        status: 'FAILED',
+        steps: [
+          {
+            id: 'step-1',
+            order: 1,
+            method: 'GET',
+            endpoint: '/api/test',
+            headers: {},
+            body: null,
+            expectedStatus: 200,
+            assertions: [],
+            extractors: [],
+            timeoutMs: 5000,
+          },
+        ],
+      }),
+    ]
+    render(<OperationCoverageTable scenarios={scenariosWithNoCovered} />)
+
+    const coveredFilter = screen.getByRole('button', { name: /covered.*0/i })
+    await user.click(coveredFilter)
+
+    expect(screen.getByTestId('no-results')).toBeInTheDocument()
+    expect(screen.getByText('No operations match the current filter')).toBeInTheDocument()
+  })
+
+  it('expands operation to show linked scenarios', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    // Click on an operation to expand
+    const operationButton = screen.getByRole('button', {
+      name: /GET \/api\/users/i,
+    })
+    await user.click(operationButton)
+
+    // Should show linked scenarios
+    expect(screen.getByTestId('scenario-list')).toBeInTheDocument()
+    expect(screen.getByText('Get Users')).toBeInTheDocument()
+  })
+
+  it('collapses operation when clicked again', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const operationButton = screen.getByRole('button', {
+      name: /GET \/api\/users/i,
+    })
+
+    // Expand
+    await user.click(operationButton)
+    expect(screen.getByTestId('scenario-list')).toBeInTheDocument()
+
+    // Collapse
+    await user.click(operationButton)
+    expect(screen.queryByTestId('scenario-list')).not.toBeInTheDocument()
+  })
+
+  it('only one operation expanded at a time', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    // Expand first operation
+    const firstOperation = screen.getByRole('button', {
+      name: /GET \/api\/users/i,
+    })
+    await user.click(firstOperation)
+    expect(screen.getByText('Get Users')).toBeInTheDocument()
+
+    // Expand second operation
+    const secondOperation = screen.getByRole('button', {
+      name: /POST \/api\/users/i,
+    })
+    await user.click(secondOperation)
+
+    // First should be collapsed, second should be expanded
+    expect(screen.queryByText('Get Users')).not.toBeInTheDocument()
+    expect(screen.getByText('Create User')).toBeInTheDocument()
+  })
+
+  it('renders export button when onExport is provided', () => {
+    const mockExport = vi.fn()
+    render(<OperationCoverageTable scenarios={mockScenarios} onExport={mockExport} />)
+
+    expect(screen.getByRole('button', { name: /export coverage report/i })).toBeInTheDocument()
+  })
+
+  it('does not render export button when onExport is not provided', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    expect(screen.queryByRole('button', { name: /export coverage report/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onExport when export button is clicked', async () => {
+    const user = userEvent.setup()
+    const mockExport = vi.fn()
+    render(<OperationCoverageTable scenarios={mockScenarios} onExport={mockExport} />)
+
+    await user.click(screen.getByRole('button', { name: /export coverage report/i }))
+
+    expect(mockExport).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows loading state on export button when isExporting', () => {
+    const mockExport = vi.fn()
+    render(
+      <OperationCoverageTable
+        scenarios={mockScenarios}
+        onExport={mockExport}
+        isExporting={true}
+      />
+    )
+
+    expect(screen.getByText('Exporting...')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /export coverage report/i })).toBeDisabled()
+  })
+
+  it('displays progress bar with correct aria attributes', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const progressBar = screen.getByRole('meter')
+    expect(progressBar).toHaveAttribute('aria-valuenow', '50')
+    expect(progressBar).toHaveAttribute('aria-valuemin', '0')
+    expect(progressBar).toHaveAttribute('aria-valuemax', '100')
+  })
+
+  it('displays scenario count in operation row', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    // All 4 operations have 1 scenario each
+    expect(screen.getAllByText('1 scenario')).toHaveLength(4)
+  })
+
+  it('groups multiple scenarios for same endpoint', () => {
+    const scenariosWithDuplicateEndpoint = [
+      ...mockScenarios,
+      createScenario({
+        id: 'scenario-5',
+        name: 'Get Users - Pagination',
+        status: 'PASSED',
+        steps: [
+          {
+            id: 'step-5',
+            order: 1,
+            method: 'GET',
+            endpoint: '/api/users',
+            headers: {},
+            body: null,
+            expectedStatus: 200,
+            assertions: [],
+            extractors: [],
+            timeoutMs: 5000,
+          },
+        ],
+      }),
+    ]
+
+    render(<OperationCoverageTable scenarios={scenariosWithDuplicateEndpoint} />)
+
+    // GET /api/users should now have 2 scenarios
+    expect(screen.getByText('2 scenarios')).toBeInTheDocument()
+  })
+
+  it('shows legend with all status colors', () => {
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    expect(screen.getByText('Covered (passing tests)')).toBeInTheDocument()
+    expect(screen.getByText('Failing (tests exist)')).toBeInTheDocument()
+    expect(screen.getByText('Untested (no status)')).toBeInTheDocument()
+  })
+
+  it('filter buttons have aria-pressed attribute', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const allFilter = screen.getByRole('button', { name: /all.*4/i })
+    expect(allFilter).toHaveAttribute('aria-pressed', 'true')
+
+    const coveredFilter = screen.getByRole('button', { name: /covered.*2/i })
+    expect(coveredFilter).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(coveredFilter)
+    expect(allFilter).toHaveAttribute('aria-pressed', 'false')
+    expect(coveredFilter).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('operation buttons have aria-expanded attribute', async () => {
+    const user = userEvent.setup()
+    render(<OperationCoverageTable scenarios={mockScenarios} />)
+
+    const operationButton = screen.getByRole('button', {
+      name: /GET \/api\/users/i,
+    })
+
+    expect(operationButton).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(operationButton)
+    expect(operationButton).toHaveAttribute('aria-expanded', 'true')
+  })
+})

--- a/frontend/src/components/ui/OperationCoverageTable.tsx
+++ b/frontend/src/components/ui/OperationCoverageTable.tsx
@@ -1,0 +1,458 @@
+import { useState, useMemo, useCallback } from 'react'
+import type { Scenario, HttpMethod } from '@/api/types'
+
+export type CoverageStatus = 'covered' | 'failing' | 'untested'
+
+export interface OperationCoverage {
+  endpoint: string
+  method: HttpMethod
+  status: CoverageStatus
+  scenarioCount: number
+  scenarios: Array<{ id: string; name: string; status: string }>
+}
+
+export interface CoverageStats {
+  total: number
+  covered: number
+  failing: number
+  untested: number
+  percentage: number
+}
+
+export interface OperationCoverageTableProps {
+  scenarios: Scenario[]
+  isLoading?: boolean
+  onExport?: () => void
+  isExporting?: boolean
+}
+
+// HTTP Method colors
+const HTTP_METHOD_COLORS: Record<HttpMethod, string> = {
+  GET: 'bg-green-500/10 text-green-400 border-green-500/30',
+  POST: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+  PUT: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
+  PATCH: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
+  DELETE: 'bg-red-500/10 text-red-400 border-red-500/30',
+}
+
+export function OperationCoverageTable({
+  scenarios,
+  isLoading = false,
+  onExport,
+  isExporting = false,
+}: OperationCoverageTableProps) {
+  const [statusFilter, setStatusFilter] = useState<CoverageStatus | 'all'>('all')
+  const [expandedEndpoint, setExpandedEndpoint] = useState<string | null>(null)
+
+  // Calculate coverage from scenarios
+  const { operations, stats } = useMemo(() => {
+    if (scenarios.length === 0) {
+      return {
+        operations: [] as OperationCoverage[],
+        stats: { total: 0, covered: 0, failing: 0, untested: 0, percentage: 0 } as CoverageStats,
+      }
+    }
+
+    const operationMap = new Map<string, OperationCoverage>()
+
+    scenarios.forEach((scenario) => {
+      scenario.steps.forEach((step) => {
+        const key = `${step.method}:${step.endpoint}`
+        const existing = operationMap.get(key)
+
+        const isPassing = scenario.status === 'PASSED'
+        const isFailing = scenario.status === 'FAILED'
+
+        if (existing) {
+          existing.scenarioCount++
+          existing.scenarios.push({
+            id: scenario.id,
+            name: scenario.name,
+            status: scenario.status,
+          })
+          // Priority: covered > failing > untested
+          if (isPassing) {
+            existing.status = 'covered'
+          } else if (isFailing && existing.status === 'untested') {
+            existing.status = 'failing'
+          }
+        } else {
+          operationMap.set(key, {
+            endpoint: step.endpoint,
+            method: step.method,
+            status: isPassing ? 'covered' : isFailing ? 'failing' : 'untested',
+            scenarioCount: 1,
+            scenarios: [{
+              id: scenario.id,
+              name: scenario.name,
+              status: scenario.status,
+            }],
+          })
+        }
+      })
+    })
+
+    const operationsList = Array.from(operationMap.values())
+    const covered = operationsList.filter((e) => e.status === 'covered').length
+    const failing = operationsList.filter((e) => e.status === 'failing').length
+    const untested = operationsList.filter((e) => e.status === 'untested').length
+    const total = operationsList.length
+    const percentage = total > 0 ? Math.round((covered / total) * 100) : 0
+
+    // Sort: failing first, then covered, then untested
+    operationsList.sort((a, b) => {
+      const order: Record<CoverageStatus, number> = { failing: 0, covered: 1, untested: 2 }
+      return order[a.status] - order[b.status]
+    })
+
+    return {
+      operations: operationsList,
+      stats: { total, covered, failing, untested, percentage },
+    }
+  }, [scenarios])
+
+  // Filter operations
+  const filteredOperations = useMemo(() => {
+    if (statusFilter === 'all') return operations
+    return operations.filter((op) => op.status === statusFilter)
+  }, [operations, statusFilter])
+
+  const handleToggleExpand = useCallback((key: string) => {
+    setExpandedEndpoint((prev) => (prev === key ? null : key))
+  }, [])
+
+  const handleFilterChange = useCallback((filter: CoverageStatus | 'all') => {
+    setStatusFilter(filter)
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4" data-testid="coverage-loading">
+        <div className="h-32 bg-secondary-800 rounded-lg animate-pulse" />
+        <div className="h-64 bg-secondary-800 rounded-lg animate-pulse" />
+      </div>
+    )
+  }
+
+  if (stats.total === 0) {
+    return (
+      <div className="text-center py-12" data-testid="coverage-empty">
+        <div className="w-12 h-12 mx-auto mb-4 text-secondary-600">
+          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            />
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium text-white mb-1">No coverage data</h3>
+        <p className="text-secondary-400">
+          Generate scenarios to see API coverage information
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6" data-testid="coverage-table">
+      {/* Coverage Summary */}
+      <div className="card">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+          <h3 className="text-lg font-semibold text-white">API Coverage</h3>
+          <div className="flex items-center gap-3">
+            <span className="text-2xl font-bold text-primary-400" data-testid="coverage-percentage">
+              {stats.percentage}%
+            </span>
+            {onExport && (
+              <button
+                onClick={onExport}
+                disabled={isExporting}
+                className="btn btn-secondary text-sm disabled:opacity-50"
+                aria-label="Export coverage report"
+              >
+                {isExporting ? (
+                  <>
+                    <svg className="w-4 h-4 mr-2 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Exporting...
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-4 h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                      />
+                    </svg>
+                    Export Report
+                  </>
+                )}
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Progress Bar */}
+        <div
+          className="h-4 bg-secondary-700 rounded-full overflow-hidden mb-4"
+          role="meter"
+          aria-valuenow={stats.percentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Coverage: ${String(stats.percentage)}%`}
+        >
+          <div
+            className="h-full bg-primary-500 rounded-full transition-all duration-500"
+            style={{ width: `${String(stats.percentage)}%` }}
+          />
+        </div>
+
+        {/* Stats */}
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div className="p-3 bg-green-500/10 rounded-lg">
+            <div className="text-2xl font-bold text-green-400" data-testid="covered-count">
+              {stats.covered}
+            </div>
+            <div className="text-sm text-secondary-400">Covered</div>
+          </div>
+          <div className="p-3 bg-red-500/10 rounded-lg">
+            <div className="text-2xl font-bold text-red-400" data-testid="failing-count">
+              {stats.failing}
+            </div>
+            <div className="text-sm text-secondary-400">Failing</div>
+          </div>
+          <div className="p-3 bg-secondary-700/50 rounded-lg">
+            <div className="text-2xl font-bold text-secondary-400" data-testid="untested-count">
+              {stats.untested}
+            </div>
+            <div className="text-sm text-secondary-400">Untested</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Filter Controls */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm text-secondary-400">Filter:</span>
+        <FilterButton
+          label="All"
+          count={stats.total}
+          isActive={statusFilter === 'all'}
+          onClick={() => {
+            handleFilterChange('all')
+          }}
+        />
+        <FilterButton
+          label="Covered"
+          count={stats.covered}
+          isActive={statusFilter === 'covered'}
+          onClick={() => {
+            handleFilterChange('covered')
+          }}
+          color="green"
+        />
+        <FilterButton
+          label="Failing"
+          count={stats.failing}
+          isActive={statusFilter === 'failing'}
+          onClick={() => {
+            handleFilterChange('failing')
+          }}
+          color="red"
+        />
+        <FilterButton
+          label="Untested"
+          count={stats.untested}
+          isActive={statusFilter === 'untested'}
+          onClick={() => {
+            handleFilterChange('untested')
+          }}
+          color="gray"
+        />
+      </div>
+
+      {/* Operations Table */}
+      <div className="card">
+        <h3 className="text-lg font-semibold text-white mb-4">
+          Operation Coverage
+          <span className="text-sm font-normal text-secondary-400 ml-2">
+            ({filteredOperations.length} of {stats.total})
+          </span>
+        </h3>
+
+        {filteredOperations.length === 0 ? (
+          <div className="text-center py-8 text-secondary-400" data-testid="no-results">
+            No operations match the current filter
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {filteredOperations.map((operation) => {
+              const key = `${operation.method}:${operation.endpoint}`
+              const isExpanded = expandedEndpoint === key
+
+              return (
+                <div
+                  key={key}
+                  className="border border-secondary-700 rounded-lg overflow-hidden"
+                >
+                  <button
+                    onClick={() => {
+                      handleToggleExpand(key)
+                    }}
+                    className="w-full flex items-center gap-3 p-3 hover:bg-secondary-800/50 transition-colors text-left"
+                    aria-expanded={isExpanded}
+                    aria-label={`${operation.method} ${operation.endpoint}, ${String(operation.scenarioCount)} scenarios, ${operation.status}`}
+                  >
+                    <span
+                      className={`px-2 py-1 rounded text-xs font-mono border ${HTTP_METHOD_COLORS[operation.method]}`}
+                    >
+                      {operation.method}
+                    </span>
+                    <span className="font-mono text-white flex-1 truncate">
+                      {operation.endpoint}
+                    </span>
+                    <CoverageStatusBadge status={operation.status} />
+                    <span className="text-secondary-400 text-sm">
+                      {operation.scenarioCount} scenario{operation.scenarioCount !== 1 ? 's' : ''}
+                    </span>
+                    <svg
+                      className={`w-5 h-5 text-secondary-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M19 9l-7 7-7-7"
+                      />
+                    </svg>
+                  </button>
+
+                  {isExpanded && (
+                    <div className="px-3 pb-3 pt-1 bg-secondary-800/30" data-testid="scenario-list">
+                      <div className="text-sm text-secondary-400 mb-2">Linked Scenarios:</div>
+                      <ul className="space-y-1">
+                        {operation.scenarios.map((scenario) => (
+                          <li
+                            key={scenario.id}
+                            className="flex items-center gap-2 py-1 px-2 rounded bg-secondary-800/50"
+                          >
+                            <ScenarioStatusDot status={scenario.status} />
+                            <span className="text-white">{scenario.name}</span>
+                            <span className="text-secondary-500 text-xs">
+                              ({scenario.status})
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {/* Legend */}
+        <div className="mt-4 pt-4 border-t border-secondary-700 flex flex-wrap gap-4 sm:gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-green-500" />
+            <span className="text-secondary-400">Covered (passing tests)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-red-500" />
+            <span className="text-secondary-400">Failing (tests exist)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-3 h-3 rounded-full bg-secondary-500" />
+            <span className="text-secondary-400">Untested (no status)</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FilterButton({
+  label,
+  count,
+  isActive,
+  onClick,
+  color,
+}: {
+  label: string
+  count: number
+  isActive: boolean
+  onClick: () => void
+  color?: 'green' | 'red' | 'gray'
+}) {
+  const colorClasses = {
+    green: 'bg-green-500/10 text-green-400 border-green-500/30',
+    red: 'bg-red-500/10 text-red-400 border-red-500/30',
+    gray: 'bg-secondary-700/50 text-secondary-400 border-secondary-600',
+  }
+
+  const baseClasses = color ? colorClasses[color] : 'bg-secondary-700/50 text-white border-secondary-600'
+  const activeClasses = isActive ? 'ring-2 ring-primary-500 ring-offset-1 ring-offset-secondary-900' : ''
+
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1.5 rounded-lg border text-sm font-medium transition-all ${baseClasses} ${activeClasses}`}
+      aria-pressed={isActive}
+    >
+      {label} ({count})
+    </button>
+  )
+}
+
+function CoverageStatusBadge({ status }: { status: CoverageStatus }) {
+  const config: Record<CoverageStatus, { label: string; color: string }> = {
+    covered: { label: 'Covered', color: 'bg-green-500/10 text-green-400' },
+    failing: { label: 'Failing', color: 'bg-red-500/10 text-red-400' },
+    untested: { label: 'Untested', color: 'bg-secondary-500/10 text-secondary-400' },
+  }
+
+  const { label, color } = config[status]
+
+  return (
+    <span className={`px-2 py-1 rounded text-xs font-medium ${color}`}>
+      {label}
+    </span>
+  )
+}
+
+function ScenarioStatusDot({ status }: { status: string }) {
+  const colorMap: Record<string, string> = {
+    PASSED: 'bg-green-500',
+    FAILED: 'bg-red-500',
+    PENDING: 'bg-yellow-500',
+    RUNNING: 'bg-blue-500',
+    SKIPPED: 'bg-secondary-500',
+  }
+
+  return (
+    <span
+      className={`w-2 h-2 rounded-full ${colorMap[status] ?? 'bg-secondary-500'}`}
+      aria-label={status}
+    />
+  )
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -11,3 +11,10 @@ export { ExportDropdown } from './ExportDropdown'
 export type { ExportDropdownProps, ExportFormat } from './ExportDropdown'
 export { RetryFailedDialog } from './RetryFailedDialog'
 export type { RetryFailedDialogProps } from './RetryFailedDialog'
+export { OperationCoverageTable } from './OperationCoverageTable'
+export type {
+  OperationCoverageTableProps,
+  OperationCoverage,
+  CoverageStats,
+  CoverageStatus,
+} from './OperationCoverageTable'

--- a/frontend/src/routes/_app/packages.$packageId.tsx
+++ b/frontend/src/routes/_app/packages.$packageId.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useCallback } from 'react'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import {
   usePackage,
@@ -9,8 +9,8 @@ import {
   useUpdatePackage,
   useDeletePackage,
 } from '@/hooks'
-import { StatusBadge, Skeleton, EmptyState } from '@/components/ui'
-import type { Scenario, TestRun, HttpMethod, QaPackage, UpdateQaPackageRequest } from '@/api/types'
+import { StatusBadge, Skeleton, OperationCoverageTable } from '@/components/ui'
+import type { Scenario, TestRun, QaPackage, UpdateQaPackageRequest } from '@/api/types'
 
 export const Route = createFileRoute('/_app/packages/$packageId')({
   component: PackageDetailPage,
@@ -352,220 +352,102 @@ function RunCard({ run }: { run: TestRun }) {
   )
 }
 
-// HTTP Method colors for coverage display
-const HTTP_METHOD_COLORS: Record<HttpMethod, string> = {
-  GET: 'bg-green-500/10 text-green-400 border-green-500/30',
-  POST: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
-  PUT: 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30',
-  PATCH: 'bg-orange-500/10 text-orange-400 border-orange-500/30',
-  DELETE: 'bg-red-500/10 text-red-400 border-red-500/30',
-}
-
-type CoverageStatus = 'covered' | 'failing' | 'missing'
-
-interface EndpointCoverage {
-  endpoint: string
-  method: HttpMethod
-  status: CoverageStatus
-  scenarioCount: number
-  scenarioIds: string[]
-}
-
 function CoverageTab({ scenarios, isLoading }: { scenarios: Scenario[]; isLoading: boolean }) {
-  // Calculate coverage from scenarios
-  const coverage = useMemo(() => {
-    if (scenarios.length === 0) {
-      return {
-        endpoints: [] as EndpointCoverage[],
-        covered: 0,
-        failing: 0,
-        missing: 0,
-        total: 0,
-        percentage: 0,
-      }
+  const [isExporting, setIsExporting] = useState(false)
+
+  const handleExport = useCallback(() => {
+    setIsExporting(true)
+    try {
+      // Generate coverage report as JSON
+      const coverage = generateCoverageReport(scenarios)
+      const blob = new Blob([JSON.stringify(coverage, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      const dateStr = new Date().toISOString().split('T')[0] ?? 'export'
+      link.download = `coverage-report-${dateStr}.json`
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } finally {
+      setIsExporting(false)
     }
-
-    // Extract unique endpoints from all scenarios
-    const endpointMap = new Map<string, EndpointCoverage>()
-
-    scenarios.forEach((scenario) => {
-      scenario.steps.forEach((step) => {
-        const key = `${step.method}:${step.endpoint}`
-        const existing = endpointMap.get(key)
-
-        // Determine status based on scenario status
-        const isPassing = scenario.status === 'PASSED'
-        const isFailing = scenario.status === 'FAILED'
-
-        if (existing) {
-          existing.scenarioCount++
-          existing.scenarioIds.push(scenario.id)
-          // If any scenario is passing, mark as covered; else if failing, mark as failing
-          if (isPassing && existing.status !== 'covered') {
-            existing.status = 'covered'
-          } else if (isFailing && existing.status === 'missing') {
-            existing.status = 'failing'
-          }
-        } else {
-          endpointMap.set(key, {
-            endpoint: step.endpoint,
-            method: step.method,
-            status: isPassing ? 'covered' : isFailing ? 'failing' : 'missing',
-            scenarioCount: 1,
-            scenarioIds: [scenario.id],
-          })
-        }
-      })
-    })
-
-    const endpoints = Array.from(endpointMap.values())
-    const covered = endpoints.filter((e) => e.status === 'covered').length
-    const failing = endpoints.filter((e) => e.status === 'failing').length
-    const missing = endpoints.filter((e) => e.status === 'missing').length
-    const total = endpoints.length
-    const percentage = total > 0 ? Math.round((covered / total) * 100) : 0
-
-    // Sort: failing first, then covered, then missing
-    endpoints.sort((a, b) => {
-      const order: Record<CoverageStatus, number> = { failing: 0, covered: 1, missing: 2 }
-      return order[a.status] - order[b.status]
-    })
-
-    return { endpoints, covered, failing, missing, total, percentage }
   }, [scenarios])
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <Skeleton className="h-32" />
-        <Skeleton className="h-64" />
-      </div>
-    )
-  }
-
-  if (coverage.total === 0) {
-    return (
-      <EmptyState
-        title="No coverage data"
-        description="Generate scenarios to see API coverage information"
-        icon={
-          <svg className="w-full h-full" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
-            />
-          </svg>
-        }
-      />
-    )
-  }
-
   return (
-    <div className="space-y-6">
-      {/* Coverage Summary */}
-      <div className="card">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-white">API Coverage</h3>
-          <span className="text-2xl font-bold text-primary-400">{coverage.percentage}%</span>
-        </div>
-
-        {/* Progress Bar */}
-        <div className="h-4 bg-secondary-700 rounded-full overflow-hidden mb-4">
-          <div
-            className="h-full bg-primary-500 rounded-full transition-all duration-500"
-            style={{ width: `${String(coverage.percentage)}%` }}
-          />
-        </div>
-
-        {/* Stats */}
-        <div className="grid grid-cols-3 gap-4 text-center">
-          <div className="p-3 bg-green-500/10 rounded-lg">
-            <div className="text-2xl font-bold text-green-400">{coverage.covered}</div>
-            <div className="text-sm text-secondary-400">Covered</div>
-          </div>
-          <div className="p-3 bg-red-500/10 rounded-lg">
-            <div className="text-2xl font-bold text-red-400">{coverage.failing}</div>
-            <div className="text-sm text-secondary-400">Failing</div>
-          </div>
-          <div className="p-3 bg-secondary-700/50 rounded-lg">
-            <div className="text-2xl font-bold text-secondary-400">{coverage.missing}</div>
-            <div className="text-sm text-secondary-400">Pending</div>
-          </div>
-        </div>
-      </div>
-
-      {/* Endpoint Coverage Table */}
-      <div className="card">
-        <h3 className="text-lg font-semibold text-white mb-4">Endpoint Coverage</h3>
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead>
-              <tr className="text-left text-secondary-400 text-sm border-b border-secondary-700">
-                <th className="pb-3 pr-4">Endpoint</th>
-                <th className="pb-3 px-4">Method</th>
-                <th className="pb-3 px-4">Status</th>
-                <th className="pb-3 pl-4 text-right">Scenarios</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-secondary-700">
-              {coverage.endpoints.map((endpoint, index) => (
-                <tr key={`${endpoint.method}-${endpoint.endpoint}-${String(index)}`} className="hover:bg-secondary-800/50">
-                  <td className="py-3 pr-4">
-                    <span className="font-mono text-white">{endpoint.endpoint}</span>
-                  </td>
-                  <td className="py-3 px-4">
-                    <span className={`px-2 py-1 rounded text-xs font-mono border ${HTTP_METHOD_COLORS[endpoint.method]}`}>
-                      {endpoint.method}
-                    </span>
-                  </td>
-                  <td className="py-3 px-4">
-                    <CoverageStatusBadge status={endpoint.status} />
-                  </td>
-                  <td className="py-3 pl-4 text-right text-secondary-400">
-                    {endpoint.scenarioCount}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Legend */}
-        <div className="mt-4 pt-4 border-t border-secondary-700 flex gap-6 text-sm">
-          <div className="flex items-center gap-2">
-            <span className="w-3 h-3 rounded-full bg-green-500"></span>
-            <span className="text-secondary-400">Covered (passing)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="w-3 h-3 rounded-full bg-red-500"></span>
-            <span className="text-secondary-400">Failing (has tests)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="w-3 h-3 rounded-full bg-secondary-500"></span>
-            <span className="text-secondary-400">Pending (no status)</span>
-          </div>
-        </div>
-      </div>
-    </div>
+    <OperationCoverageTable
+      scenarios={scenarios}
+      isLoading={isLoading}
+      onExport={handleExport}
+      isExporting={isExporting}
+    />
   )
 }
 
-function CoverageStatusBadge({ status }: { status: CoverageStatus }) {
-  const config: Record<CoverageStatus, { label: string; color: string }> = {
-    covered: { label: 'Covered', color: 'bg-green-500/10 text-green-400' },
-    failing: { label: 'Failing', color: 'bg-red-500/10 text-red-400' },
-    missing: { label: 'Pending', color: 'bg-secondary-500/10 text-secondary-400' },
+function generateCoverageReport(scenarios: Scenario[]) {
+  const operationMap = new Map<string, {
+    endpoint: string
+    method: string
+    status: string
+    scenarioCount: number
+    scenarios: Array<{ id: string; name: string; status: string }>
+  }>()
+
+  scenarios.forEach((scenario) => {
+    scenario.steps.forEach((step) => {
+      const key = `${step.method}:${step.endpoint}`
+      const existing = operationMap.get(key)
+
+      const isPassing = scenario.status === 'PASSED'
+      const isFailing = scenario.status === 'FAILED'
+
+      if (existing) {
+        existing.scenarioCount++
+        existing.scenarios.push({
+          id: scenario.id,
+          name: scenario.name,
+          status: scenario.status,
+        })
+        if (isPassing) {
+          existing.status = 'covered'
+        } else if (isFailing && existing.status === 'untested') {
+          existing.status = 'failing'
+        }
+      } else {
+        operationMap.set(key, {
+          endpoint: step.endpoint,
+          method: step.method,
+          status: isPassing ? 'covered' : isFailing ? 'failing' : 'untested',
+          scenarioCount: 1,
+          scenarios: [{
+            id: scenario.id,
+            name: scenario.name,
+            status: scenario.status,
+          }],
+        })
+      }
+    })
+  })
+
+  const operations = Array.from(operationMap.values())
+  const covered = operations.filter((e) => e.status === 'covered').length
+  const failing = operations.filter((e) => e.status === 'failing').length
+  const untested = operations.filter((e) => e.status === 'untested').length
+  const total = operations.length
+  const percentage = total > 0 ? Math.round((covered / total) * 100) : 0
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      total,
+      covered,
+      failing,
+      untested,
+      percentage,
+    },
+    operations,
   }
-
-  const { label, color } = config[status]
-
-  return (
-    <span className={`px-2 py-1 rounded text-xs font-medium ${color}`}>
-      {label}
-    </span>
-  )
 }
 
 function SettingsTab({ pkg, packageId }: { pkg: QaPackage; packageId: string }) {


### PR DESCRIPTION
## Summary
- Create `OperationCoverageTable` component for per-operation coverage visualization
- Add filtering by coverage status (covered/failing/untested)
- Add expandable rows to see linked scenarios
- Add export coverage report functionality (JSON download)
- Full accessibility support with ARIA attributes
- Comprehensive test coverage (26 tests)

## Features
- **Coverage Summary**: Shows overall percentage with covered/failing/untested counts
- **Status Filtering**: Filter operations by coverage status
- **Expandable Rows**: Click any operation to see linked scenarios
- **Export Report**: Download coverage data as JSON file
- **Responsive Design**: Works on all screen sizes
- **Accessibility**: Progress meter with ARIA, keyboard navigation

## Changes
- `OperationCoverageTable.tsx` - Main coverage visualization component
- `OperationCoverageTable.test.tsx` - 26 comprehensive tests
- `packages.$packageId.tsx` - Updated CoverageTab to use new component
- `index.ts` - Export new component and types

## Test plan
- [ ] Run `npm run test` - all 102 tests pass
- [ ] Run `npm run lint` - no errors
- [ ] Run `npm run typecheck` - no errors
- [ ] Verify coverage tab shows operations with correct status indicators
- [ ] Verify filtering by status works correctly
- [ ] Verify clicking operation shows linked scenarios
- [ ] Verify export button downloads JSON file
- [ ] Verify responsive design on mobile

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)