### PR TITLE
[Backend] feat: implement shareable run links (#314)

### DIFF
--- a/backend/src/main/kotlin/com/qawave/application/service/ShareService.kt
+++ b/backend/src/main/kotlin/com/qawave/application/service/ShareService.kt
@@ -1,0 +1,186 @@
+package com.qawave.application.service
+
+import com.qawave.domain.model.ShareToken
+import com.qawave.domain.model.ShareTokenId
+import com.qawave.domain.model.TestRun
+import com.qawave.domain.model.TestRunId
+import com.qawave.infrastructure.persistence.entity.ShareTokenEntity
+import com.qawave.infrastructure.persistence.repository.ShareTokenR2dbcRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Service for managing shareable run links.
+ */
+interface ShareService {
+    /**
+     * Create a shareable link for a test run.
+     */
+    suspend fun createShare(
+        runId: TestRunId,
+        createdBy: String,
+        expirationDays: Long = 7,
+    ): ShareToken
+
+    /**
+     * Get shared run data by token.
+     * Returns null if token is invalid, expired, or revoked.
+     */
+    suspend fun getSharedRun(token: String): SharedRunResult?
+
+    /**
+     * Revoke a share token.
+     */
+    suspend fun revokeShare(
+        tokenId: ShareTokenId,
+        userId: String,
+    ): Boolean
+
+    /**
+     * Get all active shares for a run.
+     */
+    suspend fun getActiveSharesForRun(runId: TestRunId): List<ShareToken>
+
+    /**
+     * Get all shares created by a user.
+     */
+    fun getSharesByUser(userId: String): Flow<ShareToken>
+
+    /**
+     * Count active shares for a run.
+     */
+    suspend fun countActiveSharesForRun(runId: TestRunId): Long
+}
+
+/**
+ * Result of fetching a shared run.
+ */
+data class SharedRunResult(
+    val run: TestRun,
+    val shareToken: ShareToken,
+)
+
+@Service
+class ShareServiceImpl(
+    private val shareTokenRepository: ShareTokenR2dbcRepository,
+    private val testExecutionService: TestExecutionService,
+) : ShareService {
+    private val logger = LoggerFactory.getLogger(ShareServiceImpl::class.java)
+
+    override suspend fun createShare(
+        runId: TestRunId,
+        createdBy: String,
+        expirationDays: Long,
+    ): ShareToken {
+        // Verify run exists
+        testExecutionService.findById(runId)
+            ?: throw ShareNotFoundException("Test run not found: $runId")
+
+        // Create the share token
+        val shareToken =
+            ShareToken.create(
+                runId = runId,
+                createdBy = createdBy,
+                expirationDays = expirationDays,
+            )
+
+        // Save to database
+        val entity = shareToken.toEntity()
+        val saved = shareTokenRepository.save(entity)
+
+        logger.info("Created share token for run {} by user {}", runId, createdBy)
+
+        return saved.toDomain()
+    }
+
+    override suspend fun getSharedRun(token: String): SharedRunResult? {
+        val entity = shareTokenRepository.findByToken(token) ?: return null
+        val shareToken = entity.toDomain()
+
+        // Check if token is valid
+        if (!shareToken.isValid()) {
+            logger.debug("Share token {} is invalid (expired or revoked)", token)
+            return null
+        }
+
+        // Get the run
+        val run =
+            testExecutionService.findByIdWithResults(shareToken.runId)
+                ?: return null
+
+        // Increment view count
+        val updatedToken = shareToken.incrementViewCount()
+        shareTokenRepository.save(updatedToken.toEntity())
+
+        return SharedRunResult(run = run, shareToken = updatedToken)
+    }
+
+    override suspend fun revokeShare(
+        tokenId: ShareTokenId,
+        userId: String,
+    ): Boolean {
+        val entity = shareTokenRepository.findById(tokenId.value) ?: return false
+
+        // Verify ownership
+        if (entity.createdBy != userId) {
+            logger.warn("User {} attempted to revoke share token {} owned by {}", userId, tokenId, entity.createdBy)
+            return false
+        }
+
+        // Revoke the token
+        val revokedEntity = entity.copy(revokedAt = java.time.Instant.now())
+        shareTokenRepository.save(revokedEntity)
+
+        logger.info("Share token {} revoked by user {}", tokenId, userId)
+        return true
+    }
+
+    override suspend fun getActiveSharesForRun(runId: TestRunId): List<ShareToken> {
+        return shareTokenRepository.findActiveByRunId(runId.value)
+            .map { it.toDomain() }
+            .toList()
+    }
+
+    override fun getSharesByUser(userId: String): Flow<ShareToken> {
+        return shareTokenRepository.findByCreatedBy(userId)
+            .map { it.toDomain() }
+    }
+
+    override suspend fun countActiveSharesForRun(runId: TestRunId): Long {
+        return shareTokenRepository.countActiveByRunId(runId.value)
+    }
+
+    private fun ShareToken.toEntity(): ShareTokenEntity {
+        return ShareTokenEntity(
+            id = id.value,
+            runId = runId.value,
+            token = token,
+            expiresAt = expiresAt,
+            viewCount = viewCount,
+            createdBy = createdBy,
+            createdAt = createdAt,
+            revokedAt = revokedAt,
+        )
+    }
+
+    private fun ShareTokenEntity.toDomain(): ShareToken {
+        return ShareToken(
+            id = ShareTokenId(id!!),
+            runId = TestRunId(runId),
+            token = token,
+            expiresAt = expiresAt,
+            viewCount = viewCount,
+            createdBy = createdBy,
+            createdAt = createdAt,
+            revokedAt = revokedAt,
+        )
+    }
+}
+
+/**
+ * Exception thrown when a share resource is not found.
+ */
+class ShareNotFoundException(message: String) : RuntimeException(message)

--- a/backend/src/main/kotlin/com/qawave/domain/model/Identifiers.kt
+++ b/backend/src/main/kotlin/com/qawave/domain/model/Identifiers.kt
@@ -86,3 +86,17 @@ value class RequirementId(val value: UUID) {
 
     override fun toString(): String = value.toString()
 }
+
+/**
+ * Value class for Share Token identifier.
+ */
+@JvmInline
+value class ShareTokenId(val value: UUID) {
+    companion object {
+        fun generate(): ShareTokenId = ShareTokenId(UUID.randomUUID())
+
+        fun from(string: String): ShareTokenId = ShareTokenId(UUID.fromString(string))
+    }
+
+    override fun toString(): String = value.toString()
+}

--- a/backend/src/main/kotlin/com/qawave/domain/model/ShareToken.kt
+++ b/backend/src/main/kotlin/com/qawave/domain/model/ShareToken.kt
@@ -1,0 +1,75 @@
+package com.qawave.domain.model
+
+import java.security.SecureRandom
+import java.time.Instant
+
+/**
+ * Domain model for a share token that enables public access to test run results.
+ */
+data class ShareToken(
+    val id: ShareTokenId,
+    val runId: TestRunId,
+    val token: String,
+    val expiresAt: Instant,
+    val viewCount: Int = 0,
+    val createdBy: String,
+    val createdAt: Instant = Instant.now(),
+    val revokedAt: Instant? = null,
+) {
+    companion object {
+        private const val TOKEN_LENGTH = 32
+        private val secureRandom = SecureRandom()
+        private const val TOKEN_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+        /**
+         * Generate a secure random token.
+         */
+        fun generateToken(): String {
+            return (1..TOKEN_LENGTH)
+                .map { TOKEN_CHARS[secureRandom.nextInt(TOKEN_CHARS.length)] }
+                .joinToString("")
+        }
+
+        /**
+         * Create a new share token with default expiration (7 days).
+         */
+        fun create(
+            runId: TestRunId,
+            createdBy: String,
+            expirationDays: Long = 7,
+        ): ShareToken {
+            return ShareToken(
+                id = ShareTokenId.generate(),
+                runId = runId,
+                token = generateToken(),
+                expiresAt = Instant.now().plusSeconds(expirationDays * 24 * 60 * 60),
+                createdBy = createdBy,
+            )
+        }
+    }
+
+    /**
+     * Check if this token is still valid (not expired and not revoked).
+     */
+    fun isValid(): Boolean = revokedAt == null && expiresAt.isAfter(Instant.now())
+
+    /**
+     * Check if this token has been revoked.
+     */
+    fun isRevoked(): Boolean = revokedAt != null
+
+    /**
+     * Check if this token has expired.
+     */
+    fun isExpired(): Boolean = expiresAt.isBefore(Instant.now())
+
+    /**
+     * Create a copy with incremented view count.
+     */
+    fun incrementViewCount(): ShareToken = copy(viewCount = viewCount + 1)
+
+    /**
+     * Create a copy marked as revoked.
+     */
+    fun revoke(): ShareToken = copy(revokedAt = Instant.now())
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/persistence/entity/ShareTokenEntity.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/persistence/entity/ShareTokenEntity.kt
@@ -1,0 +1,33 @@
+package com.qawave.infrastructure.persistence.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Column
+import org.springframework.data.relational.core.mapping.Table
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * R2DBC entity for Share Token.
+ * Maps to the share_tokens table in PostgreSQL.
+ */
+@Table("share_tokens")
+data class ShareTokenEntity(
+    @Id
+    val id: UUID? = null,
+    @Column("run_id")
+    val runId: UUID,
+    @Column("token")
+    val token: String,
+    @Column("expires_at")
+    val expiresAt: Instant,
+    @Column("view_count")
+    val viewCount: Int = 0,
+    @Column("created_by")
+    val createdBy: String,
+    @CreatedDate
+    @Column("created_at")
+    val createdAt: Instant = Instant.now(),
+    @Column("revoked_at")
+    val revokedAt: Instant? = null,
+)

--- a/backend/src/main/kotlin/com/qawave/infrastructure/persistence/repository/ShareTokenR2dbcRepository.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/persistence/repository/ShareTokenR2dbcRepository.kt
@@ -1,0 +1,75 @@
+package com.qawave.infrastructure.persistence.repository
+
+import com.qawave.infrastructure.persistence.entity.ShareTokenEntity
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.r2dbc.repository.Query
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+/**
+ * R2DBC repository for Share Tokens.
+ * Uses Kotlin coroutines for non-blocking database access.
+ */
+@Repository
+interface ShareTokenR2dbcRepository : CoroutineCrudRepository<ShareTokenEntity, UUID> {
+    /**
+     * Find a share token by its token string.
+     */
+    suspend fun findByToken(token: String): ShareTokenEntity?
+
+    /**
+     * Find all share tokens for a run.
+     */
+    fun findByRunId(runId: UUID): Flow<ShareTokenEntity>
+
+    /**
+     * Find all active (non-expired, non-revoked) share tokens for a run.
+     */
+    @Query(
+        """
+        SELECT * FROM share_tokens
+        WHERE run_id = :runId
+        AND revoked_at IS NULL
+        AND expires_at > NOW()
+        ORDER BY created_at DESC
+    """,
+    )
+    fun findActiveByRunId(runId: UUID): Flow<ShareTokenEntity>
+
+    /**
+     * Find all share tokens created by a user.
+     */
+    fun findByCreatedBy(createdBy: String): Flow<ShareTokenEntity>
+
+    /**
+     * Count active share tokens for a run.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM share_tokens
+        WHERE run_id = :runId
+        AND revoked_at IS NULL
+        AND expires_at > NOW()
+    """,
+    )
+    suspend fun countActiveByRunId(runId: UUID): Long
+
+    /**
+     * Delete all share tokens for a run.
+     */
+    suspend fun deleteByRunId(runId: UUID)
+
+    /**
+     * Check if a token exists and is valid.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) > 0 FROM share_tokens
+        WHERE token = :token
+        AND revoked_at IS NULL
+        AND expires_at > NOW()
+    """,
+    )
+    suspend fun isTokenValid(token: String): Boolean
+}

--- a/backend/src/main/kotlin/com/qawave/infrastructure/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/qawave/infrastructure/security/SecurityConfig.kt
@@ -65,6 +65,7 @@ class SecurityConfig(
                 "/swagger-ui.html",
                 "/webjars/**",
                 "/v3/api-docs/**",
+                "/api/shared/**", // Shared run links (public access)
             )
 
         /**

--- a/backend/src/main/kotlin/com/qawave/presentation/controller/ShareController.kt
+++ b/backend/src/main/kotlin/com/qawave/presentation/controller/ShareController.kt
@@ -1,0 +1,199 @@
+package com.qawave.presentation.controller
+
+import com.qawave.application.service.ShareNotFoundException
+import com.qawave.application.service.ShareService
+import com.qawave.domain.model.ShareTokenId
+import com.qawave.domain.model.TestRunId
+import com.qawave.infrastructure.security.Roles
+import com.qawave.infrastructure.security.SecurityUtils
+import com.qawave.presentation.dto.request.CreateShareRequest
+import com.qawave.presentation.dto.response.ErrorResponse
+import com.qawave.presentation.dto.response.ShareInfoResponse
+import com.qawave.presentation.dto.response.ShareTokenResponse
+import com.qawave.presentation.dto.response.SharedRunResponse
+import com.qawave.presentation.dto.response.StepResultResponse
+import com.qawave.presentation.dto.response.TestRunResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+/**
+ * REST controller for shareable run links.
+ */
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Share", description = "Manage shareable links for test runs")
+class ShareController(
+    private val shareService: ShareService,
+) {
+    private val logger = LoggerFactory.getLogger(ShareController::class.java)
+
+    @PostMapping("/runs/{id}/share")
+    @PreAuthorize(Roles.CAN_CREATE)
+    @Operation(
+        summary = "Create a shareable link",
+        description = "Generates a unique shareable link for a test run. Requires ADMIN or TESTER role.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "Share link created"),
+        ApiResponse(responseCode = "403", description = "Insufficient permissions"),
+        ApiResponse(
+            responseCode = "404",
+            description = "Run not found",
+            content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+        ),
+    )
+    suspend fun createShare(
+        @Parameter(description = "Run ID") @PathVariable id: UUID,
+        @Valid @RequestBody(required = false) request: CreateShareRequest?,
+    ): ResponseEntity<ShareTokenResponse> {
+        val userId = SecurityUtils.getCurrentUserId() ?: "anonymous"
+        logger.info("Creating share link for run {} by user {}", id, userId)
+
+        return try {
+            val shareToken =
+                shareService.createShare(
+                    runId = TestRunId(id),
+                    createdBy = userId,
+                    expirationDays = request?.expirationDays ?: 7,
+                )
+            ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ShareTokenResponse.from(shareToken))
+        } catch (e: ShareNotFoundException) {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    @GetMapping("/runs/{id}/shares")
+    @PreAuthorize(Roles.CAN_READ)
+    @Operation(
+        summary = "List active shares for a run",
+        description = "Lists all active share tokens for a test run. Requires any authenticated role.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "List of active shares"),
+        ApiResponse(responseCode = "403", description = "Insufficient permissions"),
+    )
+    suspend fun listSharesForRun(
+        @Parameter(description = "Run ID") @PathVariable id: UUID,
+    ): ResponseEntity<List<ShareTokenResponse>> {
+        val shares = shareService.getActiveSharesForRun(TestRunId(id))
+        return ResponseEntity.ok(shares.map { ShareTokenResponse.from(it) })
+    }
+
+    @DeleteMapping("/runs/{runId}/shares/{tokenId}")
+    @PreAuthorize(Roles.CAN_CREATE)
+    @Operation(
+        summary = "Revoke a share token",
+        description = "Revokes a share token, making the link invalid. Requires ADMIN or TESTER role.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "Share revoked"),
+        ApiResponse(responseCode = "403", description = "Insufficient permissions or not owner"),
+        ApiResponse(responseCode = "404", description = "Share token not found"),
+    )
+    suspend fun revokeShare(
+        @Parameter(description = "Run ID") @PathVariable runId: UUID,
+        @Parameter(description = "Share Token ID") @PathVariable tokenId: UUID,
+    ): ResponseEntity<Unit> {
+        val userId = SecurityUtils.getCurrentUserId() ?: return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+
+        val revoked = shareService.revokeShare(ShareTokenId(tokenId), userId)
+        return if (revoked) {
+            ResponseEntity.noContent().build()
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    @GetMapping("/user/shares")
+    @PreAuthorize(Roles.CAN_READ)
+    @Operation(
+        summary = "List shares created by current user",
+        description = "Lists all share tokens created by the authenticated user.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "List of user's shares"),
+        ApiResponse(responseCode = "403", description = "Insufficient permissions"),
+    )
+    suspend fun listUserShares(): ResponseEntity<List<ShareTokenResponse>> {
+        val userId = SecurityUtils.getCurrentUserId() ?: return ResponseEntity.ok(emptyList())
+        val shares = shareService.getSharesByUser(userId).map { ShareTokenResponse.from(it) }.toList()
+        return ResponseEntity.ok(shares)
+    }
+
+    @GetMapping("/shared/{token}")
+    @Operation(
+        summary = "Access shared run data",
+        description = "Retrieves test run data via a shared token. No authentication required.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Shared run data"),
+        ApiResponse(
+            responseCode = "404",
+            description = "Invalid or expired token",
+            content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+        ),
+    )
+    suspend fun getSharedRun(
+        @Parameter(description = "Share token") @PathVariable token: String,
+    ): ResponseEntity<SharedRunResponse> {
+        logger.debug("Accessing shared run with token: {}", token.take(8) + "...")
+
+        val result = shareService.getSharedRun(token) ?: return ResponseEntity.notFound().build()
+
+        val runResponse =
+            TestRunResponse(
+                id = result.run.id.toString(),
+                scenarioId = result.run.scenarioId.toString(),
+                status = result.run.status.name,
+                startedAt = result.run.startedAt,
+                completedAt = result.run.completedAt,
+                durationMs = result.run.durationMs,
+                passedSteps = result.run.passedSteps,
+                failedSteps = result.run.failedSteps,
+                executedSteps = result.run.executedSteps,
+                passRate = result.run.passRate,
+                stepResults =
+                    result.run.stepResults.map { step ->
+                        StepResultResponse(
+                            stepIndex = step.stepIndex,
+                            stepName = step.stepName,
+                            passed = step.passed,
+                            durationMs = step.durationMs,
+                            errorMessage = step.errorMessage,
+                            executedAt = step.executedAt,
+                        )
+                    },
+            )
+
+        val shareInfo =
+            ShareInfoResponse(
+                token = result.shareToken.token,
+                expiresAt = result.shareToken.expiresAt,
+                viewCount = result.shareToken.viewCount,
+            )
+
+        return ResponseEntity.ok(SharedRunResponse(run = runResponse, shareInfo = shareInfo))
+    }
+}

--- a/backend/src/main/kotlin/com/qawave/presentation/dto/request/CreateShareRequest.kt
+++ b/backend/src/main/kotlin/com/qawave/presentation/dto/request/CreateShareRequest.kt
@@ -1,0 +1,13 @@
+package com.qawave.presentation.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+
+/**
+ * Request for creating a shareable link.
+ */
+data class CreateShareRequest(
+    @field:Min(1, message = "Expiration days must be at least 1")
+    @field:Max(30, message = "Expiration days cannot exceed 30")
+    val expirationDays: Long = 7,
+)

--- a/backend/src/main/kotlin/com/qawave/presentation/dto/response/ShareResponses.kt
+++ b/backend/src/main/kotlin/com/qawave/presentation/dto/response/ShareResponses.kt
@@ -1,0 +1,81 @@
+package com.qawave.presentation.dto.response
+
+import com.qawave.domain.model.ShareToken
+import java.time.Instant
+
+/**
+ * Response for a share token.
+ */
+data class ShareTokenResponse(
+    val id: String,
+    val runId: String,
+    val token: String,
+    val shareUrl: String,
+    val expiresAt: Instant,
+    val viewCount: Int,
+    val createdBy: String,
+    val createdAt: Instant,
+    val isActive: Boolean,
+) {
+    companion object {
+        fun from(shareToken: ShareToken, baseShareUrl: String = "/api/shared"): ShareTokenResponse {
+            return ShareTokenResponse(
+                id = shareToken.id.toString(),
+                runId = shareToken.runId.toString(),
+                token = shareToken.token,
+                shareUrl = "$baseShareUrl/${shareToken.token}",
+                expiresAt = shareToken.expiresAt,
+                viewCount = shareToken.viewCount,
+                createdBy = shareToken.createdBy,
+                createdAt = shareToken.createdAt,
+                isActive = shareToken.isValid(),
+            )
+        }
+    }
+}
+
+/**
+ * Response for accessing a shared run.
+ */
+data class SharedRunResponse(
+    val run: TestRunResponse,
+    val shareInfo: ShareInfoResponse,
+)
+
+/**
+ * Share info included in shared run response.
+ */
+data class ShareInfoResponse(
+    val token: String,
+    val expiresAt: Instant,
+    val viewCount: Int,
+)
+
+/**
+ * Simplified test run response for shared access.
+ */
+data class TestRunResponse(
+    val id: String,
+    val scenarioId: String,
+    val status: String,
+    val startedAt: Instant,
+    val completedAt: Instant?,
+    val durationMs: Long?,
+    val passedSteps: Int,
+    val failedSteps: Int,
+    val executedSteps: Int,
+    val passRate: Double,
+    val stepResults: List<StepResultResponse>,
+)
+
+/**
+ * Simplified step result for shared access.
+ */
+data class StepResultResponse(
+    val stepIndex: Int,
+    val stepName: String,
+    val passed: Boolean,
+    val durationMs: Long,
+    val errorMessage: String?,
+    val executedAt: Instant,
+)

--- a/backend/src/main/resources/db/migration/V019__create_share_tokens_table.sql
+++ b/backend/src/main/resources/db/migration/V019__create_share_tokens_table.sql
@@ -1,0 +1,59 @@
+-- V019__create_share_tokens_table.sql
+-- Description: Create share_tokens table for shareable run links
+-- Author: Backend Agent
+-- Date: 2026-01-31
+-- Issue: #314 - Implement shareable run links with unique tokens
+
+-- ============================================================================
+-- PART 1: Create share_tokens table
+-- ============================================================================
+
+CREATE TABLE share_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id UUID NOT NULL REFERENCES test_runs(id) ON DELETE CASCADE,
+    token VARCHAR(64) NOT NULL UNIQUE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    view_count INTEGER NOT NULL DEFAULT 0,
+    created_by VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT share_tokens_token_unique UNIQUE (token)
+);
+
+COMMENT ON TABLE share_tokens IS
+'Stores tokens for sharing test run results via public URLs without authentication';
+
+COMMENT ON COLUMN share_tokens.id IS 'Primary key UUID for the share token';
+COMMENT ON COLUMN share_tokens.run_id IS 'Reference to the test run being shared';
+COMMENT ON COLUMN share_tokens.token IS 'Unique secure token used in the shareable URL';
+COMMENT ON COLUMN share_tokens.expires_at IS 'When this share token expires (default 7 days from creation)';
+COMMENT ON COLUMN share_tokens.view_count IS 'Number of times this shared link has been accessed';
+COMMENT ON COLUMN share_tokens.created_by IS 'Keycloak subject ID of user who created the share';
+COMMENT ON COLUMN share_tokens.created_at IS 'When this share token was created';
+COMMENT ON COLUMN share_tokens.revoked_at IS 'When this share token was revoked (null if still active)';
+
+-- ============================================================================
+-- PART 2: Create indexes for efficient queries
+-- ============================================================================
+
+-- Index for looking up share by token (primary access pattern)
+CREATE INDEX idx_share_tokens_token ON share_tokens(token);
+
+-- Index for finding all shares for a run
+CREATE INDEX idx_share_tokens_run_id ON share_tokens(run_id);
+
+-- Index for finding shares by creator
+CREATE INDEX idx_share_tokens_created_by ON share_tokens(created_by);
+
+-- Partial index for active (non-expired, non-revoked) tokens
+CREATE INDEX idx_share_tokens_active ON share_tokens(token)
+WHERE revoked_at IS NULL AND expires_at > NOW();
+
+-- ============================================================================
+-- PART 3: Add documentation
+-- ============================================================================
+
+COMMENT ON INDEX idx_share_tokens_token IS 'Primary lookup index for share token validation';
+COMMENT ON INDEX idx_share_tokens_run_id IS 'Index for finding all share tokens for a test run';
+COMMENT ON INDEX idx_share_tokens_created_by IS 'Index for finding shares created by a user';
+COMMENT ON INDEX idx_share_tokens_active IS 'Partial index for quick active token validation';


### PR DESCRIPTION
## Summary
- Add ShareToken domain model with secure token generation using SecureRandom
- Add ShareTokenEntity and R2DBC repository for database persistence
- Add ShareService for creating, accessing, and revoking share tokens
- Add ShareController with REST endpoints for sharing functionality
- Add database migration V019 for share_tokens table with proper indexes
- Configure /api/shared/** as public endpoint in SecurityConfig

## Endpoints
- `POST /api/runs/{id}/share` - Generate shareable link with token (authenticated)
- `GET /api/shared/{token}` - Access shared run data (public, no auth required)
- `GET /api/runs/{id}/shares` - List active shares for a run (authenticated)
- `DELETE /api/runs/{runId}/shares/{tokenId}` - Revoke share (authenticated)
- `GET /api/user/shares` - List shares created by current user (authenticated)

## Features
- Configurable expiration (1-30 days, default 7 days)
- Secure random 32-character alphanumeric tokens
- View count tracking for shared links
- Token revocation support with ownership verification

## Test plan
- [ ] Verify share creation returns valid token and URL
- [ ] Verify public access to shared run data without authentication
- [ ] Verify expired tokens return 404
- [ ] Verify revoked tokens return 404
- [ ] Verify view count increments on access
- [ ] Verify only token owner can revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)