### PR TITLE
[Backend] fix: add missing AOP dependency for Resilience4j

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
 
     // Observability
     implementation("io.micrometer:micrometer-registry-prometheus")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // Structured Logging (JSON)
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")


### PR DESCRIPTION
## Summary
- Add `spring-boot-starter-aop` dependency required by Resilience4j circuit breaker annotations
- Without this dependency, the application fails to start with `ClassNotFoundException: org.aspectj.lang.ProceedingJoinPoint`

## Problem
After merging PR #340 (Webhook Notifications), the application failed to start with:
```
java.lang.ClassNotFoundException: org.aspectj.lang.ProceedingJoinPoint
```

This was caused by Resilience4j's `@CircuitBreaker` annotation requiring AspectJ for AOP proxying.

## Solution
Added `spring-boot-starter-aop` to bring in the required AspectJ weaver dependency.

## Test plan
- [x] Application starts successfully
- [x] Health check returns UP for all components (PostgreSQL, Redis)
- [x] All API endpoints accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)